### PR TITLE
fix(release): bump inter-crate version pins during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -908,7 +908,12 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           for toml in crates/*/Cargo.toml; do
-            sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" "$toml" && rm "$toml.bak"
+            # crate's own [package] version
+            sed -i.bak -E "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" "$toml"
+            # inter-crate path-dependency version pins, e.g. cli/mcp/wasm pin
+            # vastlint-core = { path = "...", version = "X" }; path-only deps untouched
+            sed -i.bak -E "s/(vastlint-[a-z-]+ = \{[^}]*version = \")[^\"]*(\")/\1${VERSION}\2/g" "$toml"
+            rm "$toml.bak"
           done
           echo "Bumped all crates to ${VERSION}"
 
@@ -1212,7 +1217,12 @@ jobs:
           # `cargo publish` always publishes the tag version, not whatever was
           # last committed in Cargo.toml.
           for toml in crates/*/Cargo.toml; do
-            sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" "$toml"
+            # crate's own [package] version
+            sed -i.bak -E "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" "$toml"
+            # inter-crate path-dependency version pins, e.g. cli/mcp/wasm pin
+            # vastlint-core = { path = "...", version = "X" }; path-only deps untouched
+            sed -i.bak -E "s/(vastlint-[a-z-]+ = \{[^}]*version = \")[^\"]*(\")/\1${VERSION}\2/g" "$toml"
+            rm "$toml.bak"
           done
           echo "Bumped all crates to ${VERSION}"
 


### PR DESCRIPTION
## Problem

The v0.6.0 release run failed on all 8 `build-cli` targets:

```
error: failed to select a version for the requirement `vastlint-core = "^0.5.0"`
candidate versions found which didn't match: 0.6.0
required by package `vastlint-cli v0.6.0`
```

The `Bump crate versions to match git tag` steps rewrote each crate's own `[package]` `version =` from the tag, but **not** the inter-crate path-dependency pins. `vastlint-cli`, `-mcp`, and `-wasm` declare `vastlint-core = { path = "...", version = "0.5.0" }` (the version is required so `cargo publish` can resolve it on crates.io). Bumping core to `0.6.0` left those pins at `^0.5.0`, which excludes `0.6.0`, so cargo refused to build.

`build-ffi` and `build-nif` passed because they pin `vastlint-core` by path only (no version).

## Fix

Both bump steps now also rewrite the path-dependency version pins to the release version. Path-only deps are untouched. Verified locally against all six crate manifests: package versions and the cli/mcp/wasm core pins go to the new version, ffi/nif stay path-only.

After merge: delete and re-push the `v0.6.0` tag (no artifacts were published in the failed run, all publish jobs were skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)