### PR TITLE
fix(deps): resolve 6 Dependabot alerts (postcss, fast-uri, linkify-it, brace-expansion)

### DIFF
--- a/examples/vastlint-client-browser/package-lock.json
+++ b/examples/vastlint-client-browser/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../npm": {
       "name": "vastlint",
-      "version": "0.4.24",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -969,7 +969,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/examples/vastlint-client-react-scratch/package-lock.json
+++ b/examples/vastlint-client-react-scratch/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../npm": {
       "name": "vastlint",
-      "version": "0.4.24",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -1509,9 +1509,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1558,9 +1558,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1578,7 +1578,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/examples/vastlint-react-demo/package-lock.json
+++ b/examples/vastlint-react-demo/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../npm": {
       "name": "vastlint",
-      "version": "0.4.24",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -1509,9 +1509,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1558,9 +1558,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1578,7 +1578,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vastlint",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vastlint",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vastlint": "file:../npm"
@@ -1957,16 +1957,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2567,7 +2567,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -3204,7 +3206,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Clears every open Dependabot alert on the repo. Lockfile-only, no source or direct-dependency changes.

## Alerts closed

| # | Severity | Package | Path | Fix |
|---|----------|---------|------|-----|
| 35 | high | postcss | `examples/vastlint-react-demo` | 8.5.15 → 8.5.23 |
| 34 | high | postcss | `examples/vastlint-client-react-scratch` | 8.5.15 → 8.5.23 |
| 33 | high | postcss | `examples/vastlint-client-browser` | 8.5.15 → 8.5.23 |
| 32 | high | fast-uri | `vscode` | 3.1.2 → 3.1.4 |
| 31 | high | fast-uri | `vscode` | 3.1.2 → 3.1.4 |
| 30 | high | linkify-it | `vscode` | 5.0.1 → 5.0.2 |

Also picks up **brace-expansion 5.0.7 → 5.0.8** (GHSA-mh99-v99m-4gvg), which `npm audit` flags in `vscode` and which the Scorecard `VulnerabilitiesID` alert (#11) lists alongside the five above. The 5.0.7 pin from PR #92 was superseded by a new advisory.

## Advisories

- GHSA-r28c-9q8g-f849 (postcss): path traversal in previous-source-map auto-loading via `sourceMappingURL`, arbitrary `.map` file disclosure
- GHSA-4c8g-83qw-93j6 (fast-uri): host confusion via failed IDN canonicalization
- GHSA-v2hh-gcrm-f6hx (fast-uri): host confusion via literal backslash authority delimiter
- GHSA-v245-v573-v5vm (linkify-it): quadratic-complexity DoS in the `mailto:` validator scan-loop
- GHSA-mh99-v99m-4gvg (brace-expansion): unbounded expansion length causing OOM crash

## Notes

All of these are transitive and dev-only: the `vscode` ones sit under the `@vscode/vsce` devDependency, the `postcss` ones under `vite` in the example apps. None ship in the published extension or in any runtime artifact. `npm audit fix` resolved everything in-range, so no `overrides` entries were needed and none of the four `package.json` files changed.

Two incidental lockfile refreshes ride along: `vscode/package-lock.json` syncs its `version` field to the 0.9.0 already in `vscode/package.json`, and the example lockfiles update the stale `file:../../npm` reference from 0.4.24 to the current 0.6.2.

## Verification

- `npm audit`: 0 vulnerabilities in root, `vscode`, `chrome`, `npm`, and all three example apps
- `cargo audit`: clean (248 crates, was already clean)
- `vscode`: `npm ci`, `npm test` (22/22 pass), `npm run bundle`, `npx vsce --version`
- examples: `npm ci` + `npm run build` for all three, all build
- `cargo test --workspace`: 11 suites, 0 failures