### PR TITLE
feat(grpc): gRPC server for openadtech.vastlint.v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,42 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  proto:
+    name: Proto contract
+    runs-on: ubuntu-latest
+    steps:
+      # buf breaking compares this commit against the tip of main, so the job
+      # needs real history rather than the default shallow clone.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '20'
+
+      # buf comes from the npm devDependency rather than buf-setup-action, so
+      # the version is pinned by package-lock.json and the workflow takes on no
+      # additional third-party action.
+      - name: Install buf
+        run: npm ci
+
+      - name: buf lint
+        run: npx buf lint
+
+      - name: buf format check
+        run: npx buf format --diff --exit-code
+
+      # The backward-compatibility gate. Any change to a published field number,
+      # field type, enum value, or RPC signature fails here rather than being
+      # caught by a consumer after release.
+      #
+      # Skipped on pushes to main, where the comparison target is the commit
+      # itself.
+      - name: buf breaking
+        if: github.event_name == 'pull_request'
+        run: npx buf breaking --against '.git#branch=main'
+
   codeql:
     name: CodeQL (SAST)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,24 @@ jobs:
       #
       # Skipped on pushes to main, where the comparison target is the commit
       # itself.
+      #
+      # The guard exists for exactly one PR: the one that introduces the
+      # contract. buf exits non-zero with "had no .proto files" when the
+      # comparison target has none, which would make the introducing PR red for
+      # a reason that is not a compatibility problem. Once main carries a proto
+      # the branch is always taken, so this cannot quietly disable the gate
+      # later: it would take deleting every .proto from main to skip it again.
       - name: buf breaking
         if: github.event_name == 'pull_request'
-        run: npx buf breaking --against '.git#branch=main'
+        run: |
+          if git ls-tree -r --name-only origin/main | grep -q '\.proto$'; then
+            npx buf breaking --against '.git#branch=main'
+          else
+            echo "main carries no .proto files yet, so there is no prior contract to"
+            echo "break. This branch should only be reachable on the PR that first"
+            echo "adds the contract."
+            exit 0
+          fi
 
   codeql:
     name: CodeQL (SAST)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1338,6 +1338,68 @@ jobs:
           cache-from: type=gha
           cache-to:   type=gha,mode=max
 
+      # The gRPC server ships as its own image rather than as a second
+      # entrypoint on the CLI image. They have different runtime shapes, and one
+      # image whose behaviour depends on an argument makes the exposed ports and
+      # the health check conditional on something the orchestrator cannot see.
+      - name: Build and push gRPC server
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: Dockerfile.grpc
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            aleksuix/vastlint-grpc:latest
+            aleksuix/vastlint-grpc:${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max
+
+  # ── Buf Schema Registry ────────────────────────────────────────────────────
+  # Publishes proto/openadtech/vastlint/v1 so consumers generate a client in any
+  # language without vendoring the file. The fourteenth distribution channel,
+  # built from the same single source of truth as the other thirteen.
+  #
+  # Prerequisites (one-time setup):
+  #   1. Create the "openadtech" organization on buf.build.
+  #   2. Create a module named "vastlint" under it.
+  #   3. Create an API token (Settings -> API tokens) and add it as the
+  #      BUF_TOKEN secret in this repo.
+  #   4. Set ENABLE_BSR_PUBLISH to "true" in repo variables.
+  #
+  # Until then this job is skipped rather than failing, matching how the Docker
+  # and npm jobs handle their own unset credentials.
+  publish-proto:
+    name: Publish to Buf Schema Registry
+    needs: [approve, build]
+    runs-on: ubuntu-latest
+    if: vars.ENABLE_BSR_PUBLISH == 'true'
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '20'
+
+      # buf comes from the npm devDependency, the same version CI already lints
+      # and breaking-checks with. Pulling a different buf here would mean the
+      # thing that publishes the contract is not the thing that validated it.
+      - name: Install buf
+        run: npm ci
+
+      # Publishing a contract that has not been checked would defeat the point
+      # of checking it.
+      - name: Verify the contract before publishing
+        run: |
+          npx buf lint
+          npx buf format --diff --exit-code
+
+      - name: Push to the registry
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+        run: npx buf push --label "${GITHUB_REF_NAME}"
+
   publish-npm:
     name: Publish to npm
     needs: [approve, build, build-wasm]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "apache-avro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fa98bc79671c7981272d91a8753a928ff6a1cd8e4f20a44c45bd5d313840bf"
+dependencies = [
+ "bigdecimal",
+ "bon",
+ "digest",
+ "log",
+ "miniz_oxide",
+ "num-bigint",
+ "quad-rand",
+ "rand",
+ "regex-lite",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +206,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +232,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1110,12 +1173,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1303,12 +1384,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1455,6 +1578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1609,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1618,6 +1756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quad-rand"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1893,36 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7956f9ac12b5712e50372d9749a3102f4810a8d42481c5eae3748d36d585bcf"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.10.0+2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2073,6 +2247,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2393,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -2409,6 +2611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -2678,6 +2892,7 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2721,12 +2936,15 @@ dependencies = [
 name = "vastlint-grpc"
 version = "0.11.7"
 dependencies = [
+ "apache-avro",
  "hdrhistogram",
  "http",
  "mimalloc",
  "prometheus",
  "prost",
  "protox",
+ "rdkafka",
+ "serde_json",
  "sha2",
  "tokio",
  "tokio-stream",
@@ -2772,6 +2990,12 @@ dependencies = [
  "rustler",
  "vastlint-core",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3083,6 +3307,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -499,12 +499,35 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -522,11 +545,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
- "darling_core",
+ "darling_core 0.24.0",
  "quote",
  "syn 3.0.2",
 ]
@@ -2069,7 +2103,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
- "darling",
+ "darling 0.24.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -2934,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "vastlint-grpc"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "apache-avro",
  "hdrhistogram",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +382,15 @@ checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -504,6 +534,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -708,6 +748,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,9 +769,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1213,6 +1267,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1292,15 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "num-traits"
@@ -1416,6 +1489,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]
@@ -2078,6 +2165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,7 +2717,10 @@ dependencies = [
 name = "vastlint-grpc"
 version = "0.11.7"
 dependencies = [
+ "hdrhistogram",
+ "http",
  "mimalloc",
+ "prometheus",
  "prost",
  "protox",
  "sha2",
@@ -2635,6 +2731,7 @@ dependencies = [
  "tonic-prost",
  "tonic-prost-build",
  "tonic-reflection",
+ "tower",
  "vastlint-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,18 +1222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,28 +1435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,12 +1578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,15 +1603,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -1927,36 +1878,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdkafka"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7956f9ac12b5712e50372d9749a3102f4810a8d42481c5eae3748d36d585bcf"
-dependencies = [
- "futures-channel",
- "futures-util",
- "libc",
- "log",
- "rdkafka-sys",
- "serde",
- "serde_derive",
- "serde_json",
- "slab",
- "tokio",
-]
-
-[[package]]
-name = "rdkafka-sys"
-version = "4.10.0+2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
-dependencies = [
- "libc",
- "libz-sys",
- "num_enum",
- "pkg-config",
 ]
 
 [[package]]
@@ -2648,18 +2569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,7 +2886,6 @@ dependencies = [
  "prometheus",
  "prost",
  "protox",
- "rdkafka",
  "serde_json",
  "sha2",
  "tokio",
@@ -3024,12 +2932,6 @@ dependencies = [
  "rustler",
  "vastlint-core",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3341,9 +3243,6 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,9 +2690,13 @@ dependencies = [
  "clap",
  "mimalloc",
  "regex",
+ "serde_json",
+ "tokio",
  "toml",
+ "tonic",
  "ureq",
  "vastlint-core",
+ "vastlint-grpc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +113,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
@@ -110,10 +170,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -247,6 +322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +498,24 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -487,6 +615,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +663,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +691,21 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -581,6 +753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,9 +768,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -614,6 +794,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -773,6 +966,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +1034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +1065,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,16 +1092,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "mimalloc"
@@ -898,6 +1207,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +1222,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "num-traits"
@@ -981,6 +1302,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1356,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,12 +1400,134 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
+dependencies = [
+ "logos 0.16.1",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos 0.15.1",
+ "miette",
+ "prost-types",
+ "thiserror",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -1348,6 +1822,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustler"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,6 +2048,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1653,6 +2166,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +2272,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +2328,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
+dependencies = [
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
+ "tempfile",
+ "tonic-build",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,11 +2430,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1872,10 +2509,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"
@@ -1966,6 +2621,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "vastlint-grpc"
+version = "0.11.7"
+dependencies = [
+ "mimalloc",
+ "prost",
+ "protox",
+ "sha2",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-health",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tonic-reflection",
+ "vastlint-core",
+]
+
+[[package]]
 name = "vastlint-mcp"
 version = "0.11.8"
 dependencies = [
@@ -1998,6 +2671,12 @@ dependencies = [
  "rustler",
  "vastlint-core",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/vastlint-cli",
     "crates/vastlint-core",
     "crates/vastlint-ffi",
+    "crates/vastlint-grpc",
     "crates/vastlint-mcp",
     "crates/vastlint-nif",
     "crates/vastlint-wasm",

--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -1,0 +1,62 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# vastlint-grpc — gRPC server image
+#
+# Separate from the CLI image on purpose. They have different entrypoints,
+# different runtime shapes (one exits, one listens), and different reasons to be
+# pulled. One image with two behaviours selected by argument would make the
+# health check, the exposed ports, and the restart policy all conditional on
+# something the orchestrator cannot see.
+#
+# Stage 1 — build a fully-static musl binary
+#
+# rust:alpine is the right base for musl static builds: Alpine ships a native
+# musl toolchain so crates with C code compile cleanly. The debian-slim +
+# musl-tools approach breaks ring because that musl-gcc wrapper does not support
+# the -m64 flag ring's build script passes.
+#
+# Notably absent: protoc. Code generation goes through protox, a protobuf
+# compiler written in Rust, so the builder needs no protobuf toolchain and the
+# image has one fewer version to keep in step with the host.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM rust:alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS builder
+
+RUN apk add --no-cache musl-dev gcc make perl
+
+WORKDIR /build
+
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+# The wire contract lives outside the crate, and build.rs reads it from here.
+COPY proto/ proto/
+
+RUN cargo build --release --bin vastlint-grpc
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 2 — final image: scratch plus the static binary
+#
+# No OS, no shell, no package manager. There is nothing in this image to
+# exploit that is not the binary itself.
+#
+# The absence of a shell is why there is no HEALTHCHECK instruction: it would
+# need one. Health checking is served over gRPC at grpc.health.v1.Health, which
+# is what Kubernetes, Envoy, and any gRPC-aware load balancer will use anyway.
+# A shell-based HTTP probe would be strictly worse and would cost the scratch
+# base to provide.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM scratch
+
+COPY --from=builder \
+     /build/target/release/vastlint-grpc \
+     /vastlint-grpc
+
+# gRPC and the Prometheus scrape endpoint.
+EXPOSE 50051 9090
+
+# Bind all interfaces: the only consumer of this image is a container runtime,
+# where localhost would make the server unreachable from anywhere useful.
+ENV VASTLINT_GRPC_ADDR=0.0.0.0:50051 \
+    VASTLINT_METRICS_ADDR=0.0.0.0:9090
+
+# No CMD. The server takes no arguments and everything is configured through the
+# environment, so an argument vector here could only be wrong.
+ENTRYPOINT ["/vastlint-grpc"]

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,22 @@
+version: v2
+
+modules:
+  - path: proto
+    name: buf.build/openadtech/vastlint
+
+lint:
+  use:
+    - STANDARD
+    # Every declaration carries a comment. This file is the only documentation a
+    # consumer who generates a client and never reads the Rust will ever see.
+    - COMMENTS
+  except:
+    # Covered by COMMENTS on the enum itself. Requiring a comment on every enum
+    # value produces restatements of the value name, which is noise.
+    - COMMENT_ENUM_VALUE
+    - COMMENT_FIELD
+    - COMMENT_RPC
+
+breaking:
+  use:
+    - FILE

--- a/crates/vastlint-cli/Cargo.toml
+++ b/crates/vastlint-cli/Cargo.toml
@@ -32,3 +32,13 @@ toml = { version = "1.1", default-features = false, features = ["parse", "serde"
 ureq = { version = "2", default-features = false, features = ["tls"] }
 # Template placeholder replacement for --ignore-pattern
 regex = { version = "1", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+# The gRPC surface, so the conformance test can compare the two surfaces
+# directly. This test lives here rather than in vastlint-grpc because cargo only
+# exposes CARGO_BIN_EXE_* for a package's own binaries, and comparing against a
+# copy of the CLI's JSON writer would prove nothing.
+vastlint-grpc = { path = "../vastlint-grpc", version = "0.11.7" }
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tonic = "0.14"

--- a/crates/vastlint-cli/Cargo.toml
+++ b/crates/vastlint-cli/Cargo.toml
@@ -38,7 +38,14 @@ regex = { version = "1", default-features = false, features = ["std"] }
 # directly. This test lives here rather than in vastlint-grpc because cargo only
 # exposes CARGO_BIN_EXE_* for a package's own binaries, and comparing against a
 # copy of the CLI's JSON writer would prove nothing.
-vastlint-grpc = { path = "../vastlint-grpc", version = "0.11.7" }
+# Path only, deliberately no version. A dev-dependency carrying a version must
+# resolve from crates.io at publish time, and vastlint-grpc is not published
+# there (same as vastlint-mcp: servers ship as images, libraries and the CLI
+# ship as crates). With a version, `cargo publish -p vastlint-cli` fails with
+# "no matching package named vastlint-grpc found" and the release stops on the
+# crate that matters most. Path-only dev-dependencies are stripped from the
+# published manifest, which is exactly what is wanted here.
+vastlint-grpc = { path = "../vastlint-grpc" }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tonic = "0.14"

--- a/crates/vastlint-cli/tests/grpc_conformance.rs
+++ b/crates/vastlint-cli/tests/grpc_conformance.rs
@@ -1,0 +1,292 @@
+//! The CLI and the gRPC surface must agree about what a document means.
+//!
+//! One rule catalog feeds several surfaces, and the value of that arrangement
+//! depends entirely on them not drifting. A rule that fires in CI but not at bid
+//! time, or a severity that differs between the two, is worse than having only
+//! one surface: it means two teams can both be right and still disagree about
+//! whether a creative ships.
+//!
+//! ## What "agree" means, and what it does not
+//!
+//! The original plan called for byte-identical JSON: "protobuf canonical JSON
+//! output must equal CLI JSON output". That target is wrong, and writing the
+//! test is what showed it. The two envelopes differ on purpose:
+//!
+//! - The CLI reports `"severity": "error"`; proto JSON reports
+//!   `"SEVERITY_ERROR"`, because a proto enum value carries its type prefix.
+//! - The CLI uses `id`, `col`, and `snake_case`; proto JSON uses `ruleId`,
+//!   `column`, and `lowerCamelCase`.
+//! - The gRPC response carries `provenance` and a four-state `detectedVersion`
+//!   that the CLI has no field for.
+//! - The CLI reports the file it read. The server never saw a file.
+//!
+//! Forcing those to match would mean degrading the richer surface to the shape
+//! of the older one. So the invariant enforced here is semantic: for the same
+//! document, both surfaces report the same verdict, the same counts, and the
+//! same findings, where a finding is its rule ID, severity, path, position, and
+//! spec reference. Presentation is free to differ; meaning is not.
+
+use std::process::Command;
+
+use serde_json::Value;
+use tonic::Request;
+use vastlint_grpc::proto::{Severity, ValidateRequest};
+use vastlint_grpc::service::VastlintApi;
+
+/// One finding, reduced to the parts both surfaces are required to agree on.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Finding {
+    rule_id: String,
+    severity: String,
+    path: Option<String>,
+    spec_ref: String,
+    line: Option<u64>,
+    column: Option<u64>,
+}
+
+/// Fixtures chosen to exercise the parts of the mapping most likely to drift.
+///
+/// Not a broad corpus: this is a conformance test between two surfaces, not a
+/// validation test. The rules themselves are covered by the core's own suite.
+fn fixtures() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            // Document-level failure: findings with no path and no position, the
+            // case where the CLI emits nulls and proto omits optional fields.
+            "unparseable",
+            "<VAST version=\"4.1\"><Ad>".to_string(),
+        ),
+        (
+            // Several errors at a known path, with line and column set.
+            "missing required children",
+            r#"<VAST version="4.1"><Ad id="1"><InLine></InLine></Ad></VAST>"#.to_string(),
+        ),
+        (
+            // Warnings and infos, not just errors, so severity mapping is
+            // exercised across all three levels.
+            "http tracking and no quartiles",
+            r#"<VAST version="4.1"><Ad id="1"><InLine><AdSystem>x</AdSystem><AdTitle>x</AdTitle><AdServingId>s</AdServingId><Impression>http://t.example.com/i</Impression><Creatives><Creative><UniversalAdId idRegistry="ad-id.org">U</UniversalAdId><Linear><Duration>00:00:15</Duration><MediaFiles><MediaFile delivery="progressive" type="video/mp4" width="640" height="360">http://cdn.example.com/a.mp4</MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>"#
+                .to_string(),
+        ),
+        (
+            // A different document type, so the type mapping is not only ever
+            // exercised on VAST.
+            "vmap",
+            r#"<vmap:VMAP xmlns:vmap="http://www.iab.net/videosuite/vmap" version="1.0"><vmap:AdBreak timeOffset="start" breakType="linear" breakId="pre"></vmap:AdBreak></vmap:VMAP>"#
+                .to_string(),
+        ),
+        (
+            // A clean document, where the agreement being tested is that both
+            // surfaces find nothing.
+            "valid",
+            r#"<VAST version="4.1"><Ad id="1"><InLine><AdSystem>Example</AdSystem><AdTitle>Ad</AdTitle><AdServingId>abc</AdServingId><Impression><![CDATA[https://t.example.com/i]]></Impression><Creatives><Creative><UniversalAdId idRegistry="ad-id.org">UID</UniversalAdId><Linear><Duration>00:00:15</Duration><TrackingEvents><Tracking event="start"><![CDATA[https://t.example.com/s]]></Tracking><Tracking event="firstQuartile"><![CDATA[https://t.example.com/q1]]></Tracking><Tracking event="midpoint"><![CDATA[https://t.example.com/m]]></Tracking><Tracking event="thirdQuartile"><![CDATA[https://t.example.com/q3]]></Tracking><Tracking event="complete"><![CDATA[https://t.example.com/c]]></Tracking></TrackingEvents><MediaFiles><MediaFile delivery="progressive" type="video/mp4" width="640" height="360"><![CDATA[https://cdn.example.com/a.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>"#
+                .to_string(),
+        ),
+    ]
+}
+
+/// Runs the real CLI binary, not a reimplementation of it.
+///
+/// `CARGO_BIN_EXE_vastlint` is why this test lives in the CLI crate: cargo only
+/// exposes that for the package's own binaries. Calling a copied version of the
+/// CLI's JSON writer would test that the copy matches itself.
+fn cli_findings(document: &str) -> (Value, Vec<Finding>) {
+    let mut file = std::env::temp_dir();
+    file.push(format!(
+        "vastlint-conformance-{}.xml",
+        // Content-derived so parallel test threads cannot collide on one path.
+        document.len() as u64 * 31 + document.bytes().map(u64::from).sum::<u64>()
+    ));
+    std::fs::write(&file, document).expect("write fixture");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vastlint"))
+        .arg("check")
+        .arg(&file)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("run the CLI");
+
+    let _ = std::fs::remove_file(&file);
+
+    let stdout = String::from_utf8(output.stdout).expect("CLI emits utf-8");
+    let json: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|error| panic!("CLI JSON did not parse: {error}\n{stdout}"));
+
+    let findings = json["issues"]
+        .as_array()
+        .expect("issues is an array")
+        .iter()
+        .map(|issue| Finding {
+            rule_id: issue["id"].as_str().expect("id").to_string(),
+            severity: issue["severity"].as_str().expect("severity").to_string(),
+            path: issue["path"].as_str().map(str::to_string),
+            spec_ref: issue["spec_ref"].as_str().expect("spec_ref").to_string(),
+            line: issue["line"].as_u64(),
+            column: issue["col"].as_u64(),
+        })
+        .collect();
+
+    (json, findings)
+}
+
+/// Calls the service in process. The transport is not what is under test here;
+/// `vastlint-grpc/tests/server.rs` covers the wire path.
+async fn grpc_findings(document: &str) -> (vastlint_grpc::proto::Verdict, Vec<Finding>) {
+    use vastlint_grpc::proto::vastlint_service_server::VastlintService;
+
+    let verdict = VastlintApi::new()
+        .validate(Request::new(ValidateRequest {
+            document: document.to_string(),
+            context: None,
+        }))
+        .await
+        .expect("validate succeeds")
+        .into_inner()
+        .verdict
+        .expect("verdict present");
+
+    let findings = verdict
+        .issues
+        .iter()
+        .map(|issue| Finding {
+            rule_id: issue.rule_id.clone(),
+            // Normalised to the CLI's spelling. The enum name is the proto
+            // convention and the lowercase word is the CLI's; neither is wrong,
+            // so one is translated rather than either being changed.
+            severity: match Severity::try_from(issue.severity).expect("known severity") {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+                Severity::Info => "info",
+                Severity::Unspecified => panic!("a finding must carry a severity"),
+            }
+            .to_string(),
+            // Proto has no null, so an absent path is the empty string. The CLI
+            // emits null. Same meaning, different encoding.
+            path: Some(issue.path.clone()).filter(|path| !path.is_empty()),
+            spec_ref: issue.spec_ref.clone(),
+            line: issue.line.map(u64::from),
+            column: issue.column.map(u64::from),
+        })
+        .collect();
+
+    (verdict, findings)
+}
+
+#[tokio::test]
+async fn both_surfaces_report_the_same_findings() {
+    for (name, document) in fixtures() {
+        let (cli_json, mut cli) = cli_findings(&document);
+        let (verdict, mut grpc) = grpc_findings(&document).await;
+
+        // Order is documented as depth-first document order on both surfaces,
+        // but the invariant under test is the set of findings. Sorting keeps a
+        // future ordering change from failing this test for the wrong reason;
+        // ordering has its own assertion below.
+        cli.sort();
+        grpc.sort();
+
+        assert_eq!(
+            cli, grpc,
+            "fixture {name:?}: the CLI and gRPC surfaces disagree about the findings"
+        );
+
+        assert_eq!(
+            cli_json["valid"].as_bool().expect("valid"),
+            verdict.valid,
+            "fixture {name:?}: disagreement about whether the document is valid"
+        );
+
+        let summary = verdict.summary.expect("summary present");
+        assert_eq!(
+            cli_json["summary"]["errors"].as_u64().expect("errors"),
+            u64::from(summary.errors),
+            "fixture {name:?}: error counts differ"
+        );
+        assert_eq!(
+            cli_json["summary"]["warnings"].as_u64().expect("warnings"),
+            u64::from(summary.warnings),
+            "fixture {name:?}: warning counts differ"
+        );
+        assert_eq!(
+            cli_json["summary"]["infos"].as_u64().expect("infos"),
+            u64::from(summary.infos),
+            "fixture {name:?}: info counts differ"
+        );
+    }
+}
+
+#[tokio::test]
+async fn both_surfaces_report_findings_in_the_same_order() {
+    for (name, document) in fixtures() {
+        let (_, cli) = cli_findings(&document);
+        let (_, grpc) = grpc_findings(&document).await;
+
+        let cli_ids: Vec<_> = cli.iter().map(|finding| &finding.rule_id).collect();
+        let grpc_ids: Vec<_> = grpc.iter().map(|finding| &finding.rule_id).collect();
+
+        assert_eq!(
+            cli_ids, grpc_ids,
+            "fixture {name:?}: both surfaces document depth-first order, so it must match"
+        );
+    }
+}
+
+#[tokio::test]
+async fn both_surfaces_agree_on_document_type_and_version() {
+    use vastlint_grpc::proto::{DocumentType, VastVersion};
+
+    for (name, document) in fixtures() {
+        let (cli_json, _) = cli_findings(&document);
+        let (verdict, _) = grpc_findings(&document).await;
+
+        let cli_type = cli_json["document_type"].as_str().expect("document_type");
+        let grpc_type = match DocumentType::try_from(verdict.document_type).expect("known type") {
+            DocumentType::Vast => "VAST",
+            DocumentType::Vmap => "VMAP",
+            DocumentType::Daast => "DAAST",
+            DocumentType::Unspecified => panic!("a verdict must carry a document type"),
+        };
+        assert_eq!(
+            cli_type, grpc_type,
+            "fixture {name:?}: document types differ"
+        );
+
+        // The CLI reports one version string, from `DetectedVersion::best`. The
+        // gRPC surface reports the whole detection state; `effective` is the
+        // field that has to line up, because it is the version validation
+        // actually ran against.
+        let detected = verdict.detected_version.expect("detected version present");
+        let grpc_version = match VastVersion::try_from(detected.effective).expect("known version") {
+            VastVersion::Unspecified => "unknown",
+            VastVersion::VastVersion20 => "2.0",
+            VastVersion::VastVersion30 => "3.0",
+            VastVersion::VastVersion40 => "4.0",
+            VastVersion::VastVersion41 => "4.1",
+            VastVersion::VastVersion42 => "4.2",
+            VastVersion::VastVersion43 => "4.3",
+            VastVersion::VastVersion44 => "4.4",
+        };
+        assert_eq!(
+            cli_json["version"].as_str().expect("version"),
+            grpc_version,
+            "fixture {name:?}: effective versions differ"
+        );
+    }
+}
+
+/// Guards the reason this test exists at all. If a fixture stops producing
+/// findings, the comparisons above still pass while checking nothing.
+#[tokio::test]
+async fn the_fixtures_actually_produce_findings() {
+    let mut total = 0;
+    for (_, document) in fixtures() {
+        let (_, grpc) = grpc_findings(&document).await;
+        total += grpc.len();
+    }
+
+    assert!(
+        total >= 5,
+        "the conformance fixtures should exercise several findings, found {total}"
+    );
+}

--- a/crates/vastlint-cli/tests/grpc_conformance.rs
+++ b/crates/vastlint-cli/tests/grpc_conformance.rs
@@ -90,28 +90,48 @@ fn fixtures() -> Vec<(&'static str, String)> {
 /// `CARGO_BIN_EXE_vastlint` is why this test lives in the CLI crate: cargo only
 /// exposes that for the package's own binaries. Calling a copied version of the
 /// CLI's JSON writer would test that the copy matches itself.
+///
+/// The document goes in over stdin rather than through a temporary file. The
+/// first version wrote a file whose name was derived from the document's
+/// content, with a comment claiming that stopped parallel tests colliding. It
+/// does the exact opposite: a content-derived name is the *same* name for every
+/// test using the same fixture, so two tests would write it, one would delete
+/// it, and the other's CLI would read nothing and emit empty stdout. It passed
+/// on macOS and failed on Linux and Windows, which is how a race announces
+/// itself. Feeding stdin removes the shared resource rather than trying to name
+/// it uniquely.
 fn cli_findings(document: &str) -> (Value, Vec<Finding>) {
-    let mut file = std::env::temp_dir();
-    file.push(format!(
-        "vastlint-conformance-{}.xml",
-        // Content-derived so parallel test threads cannot collide on one path.
-        document.len() as u64 * 31 + document.bytes().map(u64::from).sum::<u64>()
-    ));
-    std::fs::write(&file, document).expect("write fixture");
+    use std::io::Write;
+    use std::process::Stdio;
 
-    let output = Command::new(env!("CARGO_BIN_EXE_vastlint"))
+    let mut child = Command::new(env!("CARGO_BIN_EXE_vastlint"))
         .arg("check")
-        .arg(&file)
+        // "-" reads the document from stdin.
+        .arg("-")
         .arg("--format")
         .arg("json")
-        .output()
-        .expect("run the CLI");
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the CLI");
 
-    let _ = std::fs::remove_file(&file);
+    child
+        .stdin
+        .take()
+        .expect("stdin is piped")
+        .write_all(document.as_bytes())
+        .expect("write the document to the CLI");
+
+    let output = child.wait_with_output().expect("run the CLI");
 
     let stdout = String::from_utf8(output.stdout).expect("CLI emits utf-8");
-    let json: Value = serde_json::from_str(stdout.trim())
-        .unwrap_or_else(|error| panic!("CLI JSON did not parse: {error}\n{stdout}"));
+    let json: Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!(
+            "CLI JSON did not parse: {error}\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
 
     let findings = json["issues"]
         .as_array()

--- a/crates/vastlint-core/src/lib.rs
+++ b/crates/vastlint-core/src/lib.rs
@@ -599,6 +599,17 @@ impl RuleMeta {
     }
 }
 
+/// The version of this engine and of the rule catalog it carries.
+///
+/// The catalog ships inside this crate, so a single version identifies both.
+/// Callers that report a verdict to someone else should record it: a finding is
+/// only reproducible against the ruleset that produced it.
+///
+/// This names a release. It does not identify what that release actually
+/// contained, which is a different question and needs a content hash of
+/// [`all_rules`] instead. See `vastlint-grpc`'s `Provenance` for both together.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Returns the full catalog of known rules in definition order.
 ///
 /// Use this to power `vastlint rules` output or to validate config-file rule

--- a/crates/vastlint-grpc/Cargo.toml
+++ b/crates/vastlint-grpc/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name = "vastlint-grpc"
+version = "0.11.7"
+edition = "2021"
+rust-version = "1.88"  # tonic-prost-build
+authors = ["Aleks <aleks@vastlint.org>"]
+description = "gRPC server for VASTlint — exposes VAST XML validation over openadtech.vastlint.v1, with server reflection and health checking"
+license = "Apache-2.0"
+repository = "https://github.com/aleksUIX/vastlint"
+homepage = "https://vastlint.org"
+readme = "README.md"
+keywords = ["vast", "grpc", "adtech", "iab", "validation"]
+categories = ["development-tools", "network-programming"]
+
+[[bin]]
+name = "vastlint-grpc"
+path = "src/main.rs"
+
+[dependencies]
+vastlint-core = { path = "../vastlint-core", version = "0.11.7" }
+
+# gRPC transport and codegen runtime.
+tonic = "0.14"
+tonic-prost = "0.14"
+prost = "0.14"
+
+# Server reflection, so grpcurl and friends work without a local copy of the
+# proto. Same capability added to the ARTF Rust reference implementation.
+tonic-reflection = "0.14"
+
+# grpc.health.v1, required by Kubernetes readiness probes and by any load
+# balancer that health checks its upstreams.
+tonic-health = "0.14"
+
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "time"] }
+
+# Stream trait for the streaming RPC's associated type. Already in the tree via
+# tonic; named directly so the dependency is honest.
+tokio-stream = "0.1"
+
+# Catalog digest. Hashed over the linked catalog at startup, not over the source
+# file at build time: the point is to identify what this binary will actually
+# enforce.
+sha2 = "0.10"
+
+# Fast allocator, matching vastlint-mcp. Validation is allocation-heavy on the
+# hot path and this is the same workload shape.
+mimalloc = { version = "0.1", default-features = false }
+
+[build-dependencies]
+tonic-prost-build = "0.14"
+
+# Pure-Rust protobuf compiler, so the build needs no `protoc` on PATH. See the
+# note at the top of build.rs.
+protox = "0.9"
+prost = "0.14"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "net"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+vastlint-core = { path = "../vastlint-core", version = "0.11.7" }

--- a/crates/vastlint-grpc/Cargo.toml
+++ b/crates/vastlint-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vastlint-grpc"
-version = "0.11.7"
+version = "0.11.8"
 edition = "2021"
 rust-version = "1.88"  # tonic-prost-build
 authors = ["Aleks <aleks@vastlint.org>"]
@@ -17,7 +17,7 @@ name = "vastlint-grpc"
 path = "src/main.rs"
 
 [dependencies]
-vastlint-core = { path = "../vastlint-core", version = "0.11.7" }
+vastlint-core = { path = "../vastlint-core", version = "0.11.8" }
 
 # gRPC transport and codegen runtime.
 tonic = "0.14"
@@ -86,4 +86,4 @@ serde_json = "1"
 hdrhistogram = "7.6.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-vastlint-core = { path = "../vastlint-core", version = "0.11.7" }
+vastlint-core = { path = "../vastlint-core", version = "0.11.8" }

--- a/crates/vastlint-grpc/Cargo.toml
+++ b/crates/vastlint-grpc/Cargo.toml
@@ -43,6 +43,10 @@ tokio-stream = "0.1"
 # enforce.
 sha2 = "0.10"
 
+# Avro encoding for the results stream. See src/events.rs for why the topic
+# uses Avro while the wire contract uses protobuf.
+apache-avro = "0.21"
+
 # Fast allocator, matching vastlint-mcp. Validation is allocation-heavy on the
 # hot path and this is the same workload shape.
 mimalloc = { version = "0.1", default-features = false }
@@ -59,6 +63,9 @@ http = "1"
 # in that format is a poor trade.
 prometheus = { version = "0.14", default-features = false }
 
+# Optional Kafka producer. See the `kafka` feature.
+rdkafka = { version = "0.39", optional = true, default-features = false, features = ["libz", "tokio"] }
+
 [build-dependencies]
 tonic-prost-build = "0.14"
 
@@ -67,7 +74,15 @@ tonic-prost-build = "0.14"
 protox = "0.9"
 prost = "0.14"
 
+[features]
+default = []
+# Publishes validation events to Kafka. Off by default because rdkafka builds a
+# vendored librdkafka, which is a minutes-long C build that every developer and
+# CI job would otherwise pay for to get a feature most deployments do not use.
+kafka = ["dep:rdkafka"]
+
 [dev-dependencies]
+serde_json = "1"
 hdrhistogram = "7.6.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/crates/vastlint-grpc/Cargo.toml
+++ b/crates/vastlint-grpc/Cargo.toml
@@ -63,8 +63,6 @@ http = "1"
 # in that format is a poor trade.
 prometheus = { version = "0.14", default-features = false }
 
-# Optional Kafka producer. See the `kafka` feature.
-rdkafka = { version = "0.39", optional = true, default-features = false, features = ["libz", "tokio"] }
 
 [build-dependencies]
 tonic-prost-build = "0.14"
@@ -73,13 +71,6 @@ tonic-prost-build = "0.14"
 # note at the top of build.rs.
 protox = "0.9"
 prost = "0.14"
-
-[features]
-default = []
-# Publishes validation events to Kafka. Off by default because rdkafka builds a
-# vendored librdkafka, which is a minutes-long C build that every developer and
-# CI job would otherwise pay for to get a feature most deployments do not use.
-kafka = ["dep:rdkafka"]
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/vastlint-grpc/Cargo.toml
+++ b/crates/vastlint-grpc/Cargo.toml
@@ -47,6 +47,18 @@ sha2 = "0.10"
 # hot path and this is the same workload shape.
 mimalloc = { version = "0.1", default-features = false }
 
+# Middleware stack for the concurrency limiter and the rate limiter. The limit
+# layer is written here rather than taken from tower, because tower's is static
+# and the whole point is that the right limit is not knowable in advance.
+tower = { version = "0.5", features = ["util"] }
+http = "1"
+
+# Metrics. default-features off drops the protobuf exposition format and the
+# `protobuf` crate with it: only the text format is served, and pulling in a
+# second protobuf implementation alongside prost to render metrics nobody reads
+# in that format is a poor trade.
+prometheus = { version = "0.14", default-features = false }
+
 [build-dependencies]
 tonic-prost-build = "0.14"
 
@@ -56,6 +68,7 @@ protox = "0.9"
 prost = "0.14"
 
 [dev-dependencies]
+hdrhistogram = "7.6.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 vastlint-core = { path = "../vastlint-core", version = "0.11.7" }

--- a/crates/vastlint-grpc/LOAD-TEST.md
+++ b/crates/vastlint-grpc/LOAD-TEST.md
@@ -1,0 +1,134 @@
+# Load test: does the adaptive limiter actually bound tail latency
+
+Run 2026-08-09. Everything below is measured, not modelled.
+
+The claim under test, stated before the run: **with the limiter on, p999 stays
+bounded as offered load passes capacity, and the excess turns into
+`RESOURCE_EXHAUSTED` instead of latency.**
+
+## Method
+
+Closed-loop ramp from [`examples/loadgen.rs`](examples/loadgen.rs). At each
+level, N workers issue `Validate` calls back to back for 3 seconds, so offered
+concurrency is exactly N. 500ms of warm-up is discarded at each level so the
+numbers describe steady state rather than the limiter still adapting. Latency is
+measured client-side in an HDR histogram; goodput counts successful responses
+only, since shed responses are fast and counting them would make an overloaded
+server look productive.
+
+Corpus is 80% light and 20% heavy, costing 0.068ms and 0.298ms respectively on
+this machine, a spread of 4.4x. That ratio is deliberate and matches the
+published 363µs/2,104µs benchmark ratio; the absolute numbers do not, and are
+not meant to.
+
+Both sides ran on the same machine (10 cores, macOS) with
+`VASTLINT_BLOCKING_THREADS=2`, so validation capacity is 2 threads. Client,
+server, and harness share the box, so absolute throughput is not a benchmark of
+the validator. The comparison is the result; the numbers are not.
+
+- **A side:** `VASTLINT_LIMIT_ENABLED=false`
+- **B side:** `VASTLINT_LIMIT_TARGET_LATENCY_MS=1`, everything else default
+
+## Result
+
+| Offered concurrency | p999 off (ms) | p999 on (ms) | max off (ms) | max on (ms) | goodput off /s | goodput on /s | shed |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 0.35 | 0.69 | 0.62 | 6.98 | 6,934 | 6,570 | 0 |
+| 2 | 0.37 | 0.43 | 0.58 | 0.67 | 13,666 | 13,291 | 0 |
+| 4 | 0.48 | 0.50 | 1.93 | 0.76 | 20,760 | 19,144 | 0 |
+| 8 | 1.74 | 1.35 | 11.81 | 7.00 | 23,361 | 23,375 | 30 |
+| 16 | 1.19 | 1.29 | 2.02 | 2.42 | 26,447 | 25,193 | 58 |
+| 32 | 1.66 | 2.44 | 2.27 | 4.83 | 26,478 | 24,866 | 2,160 |
+| 64 | 5.45 | 3.23 | 26.54 | 14.39 | 25,868 | 24,809 | 1,483 |
+| **128** | **47.42** | **7.79** | 51.62 | 17.57 | 24,782 | 23,075 | 7,983 |
+| **256** | **34.40** | **11.28** | 42.85 | 11.89 | 25,169 | 23,895 | 2,050 |
+
+The limiter converged to a concurrency of 22 on its own, from a starting value
+of 32, with no tuning beyond the target latency.
+
+## What it shows
+
+**The claim holds, with a cost.** Past capacity, p999 improves 6.1x at
+concurrency 128 (47.42ms to 7.79ms) and 3.0x at 256 (34.40ms to 11.28ms). Worst
+observed latency improves from 51.62ms to 17.57ms. The price is 5 to 7% of
+goodput and 2.4% of requests refused.
+
+That trade is the right one for a bid path and the wrong one for a batch job,
+which is why the limiter is configurable rather than mandatory. A caller that
+has already lost the auction gains nothing from a late answer; a nightly
+creative sweep would rather wait than be refused.
+
+**Below capacity the limiter is invisible**, which is what it should be. Through
+concurrency 16 the two curves are within noise of each other and almost nothing
+is shed. A limiter that taxed the healthy case would not be worth running.
+
+## Two findings that changed the code
+
+**The default target latency was inert.** The original 50ms was reasoned from
+per-tag benchmarks rather than measured: "363µs light and 2,104µs heavy, so 50ms
+is twenty-five heavy tags of headroom." Under saturation the server's own
+handling time never approaches 50ms, so the trigger never fired. The limiter
+shed 0.02% of requests and its latency curve was indistinguishable from having
+no limiter at all. The default is now 2ms, chosen from the measured
+distribution. A threshold nobody measured is a threshold that does nothing.
+
+**The real capacity knob was not the one being configured.** Validation is
+CPU-bound and runs on tokio's blocking pool, whose default ceiling is 512
+threads. That default is sized for blocking I/O, where threads wait. These never
+wait, so 512 of them on a 10-core machine bought no throughput and added
+context switching. Sizing the pool to the core count *raised* saturated goodput
+from roughly 26,700/s to 29,500/s. More importantly, it moved the admission
+decision to somewhere an operator can see it.
+
+## One thing the limiter does not do
+
+An earlier run constrained both the async workers and the validation pool to 2
+threads. Client-observed p99 at concurrency 256 was 8.72ms, while the server's
+own histogram showed 167,158 of 168,717 requests completing in under 1ms. Nearly
+all of the client's wait was spent before the request ever reached the limiter,
+queued in the accept path and the HTTP/2 read loop on starved worker threads.
+
+The limiter governs the work it admits. It does not govern time spent waiting to
+be admitted. Under-provisioning the I/O threads moves the queue somewhere the
+shedding policy cannot see, and the fix for that is provisioning, not a better
+shedding policy. Worth knowing before reading any tail-latency graph as proof
+that a limiter is working.
+
+## SLO
+
+Derived from these measurements rather than asserted in advance, and scoped to
+what was actually tested: single-document `Validate`, this corpus, this hardware
+class.
+
+- **Availability:** 99.9% of requests answered with a verdict or an explicit
+  `RESOURCE_EXHAUSTED`. Shedding is a successful outcome for this purpose. A
+  refusal a caller can act on is not an outage; a hang is.
+- **Latency:** p99 under 15ms and p999 under 25ms at offered concurrency up to
+  256, measured client-side, with validation capacity of 2 threads.
+- **Correctness under load:** the verdict for a document does not depend on load.
+  `Provenance` identifies the ruleset, and the same document under any
+  concurrency returns the same findings.
+
+Every number above is beaten by the measured run, deliberately. An SLO set at
+exactly the observed value is one that a slightly slower machine breaks on its
+first day.
+
+## Reproducing
+
+```sh
+cargo build --release -p vastlint-grpc --bins --examples
+
+# A side
+VASTLINT_GRPC_ADDR=127.0.0.1:50340 VASTLINT_BLOCKING_THREADS=2 \
+  VASTLINT_LIMIT_ENABLED=false ./target/release/vastlint-grpc &
+./target/release/examples/loadgen --target http://127.0.0.1:50340 \
+  --label limiter-off --csv limiter-off.csv
+
+# B side
+VASTLINT_GRPC_ADDR=127.0.0.1:50341 VASTLINT_BLOCKING_THREADS=2 \
+  VASTLINT_LIMIT_TARGET_LATENCY_MS=1 ./target/release/vastlint-grpc &
+./target/release/examples/loadgen --target http://127.0.0.1:50341 \
+  --label limiter-on --csv limiter-on.csv
+```
+
+Absolute numbers will differ. The shape should not.

--- a/crates/vastlint-grpc/README.md
+++ b/crates/vastlint-grpc/README.md
@@ -150,6 +150,72 @@ worker thread runs to completion. For vastlint that is bounded and short. It is
 still real, and it is why capacity protection needs a concurrency limit rather
 than deadlines alone. A deadline stops the waiting, not the working.
 
+## Results stream (Avro over Kafka)
+
+Off by default. A topic nobody consumes is pure cost, and turning it on should
+be a decision somebody made rather than something a default did.
+
+```sh
+VASTLINT_EVENTS_ENABLED=true \
+VASTLINT_SCHEMA_ID=42 \
+VASTLINT_KAFKA_BROKERS=localhost:9092 \
+VASTLINT_KAFKA_TOPIC=vastlint.validation.v1 \
+  cargo run --release -p vastlint-grpc --features kafka
+```
+
+The motivating case is an SSP that wants a stream of creative rejections rather
+than a request-response call: it has no document to ask about, it wants to know
+which ones are failing.
+
+**Why Avro here and protobuf on the wire.** Not inconsistency. A gRPC contract
+is a *call* contract between two parties who are both present, and both can be
+told to upgrade, which is what `buf breaking` enforces at commit time. A topic
+is a *storage* contract with readers who are not present: records written today
+are read months later by consumers running schema versions nobody chose. Avro
+carries the writer schema's identity in every record and resolves readers
+against it, which is built for exactly that.
+
+**BACKWARD compatibility is proven, not just configured.** The subject is
+registered BACKWARD, so a reader on the current schema can read every record
+ever written. A registry enforces that once, at registration, when somebody
+remembers to register. [`tests/schema_compatibility.rs`](tests/schema_compatibility.rs)
+enforces it on every commit, including the cases that must fail: adding a field
+without a default, and renaming one. Same argument as `buf breaking` versus a
+review convention, reached from the other direction.
+
+**Publishing never blocks validation.** Events go onto a bounded queue and are
+dropped when it is full, counted in `vastlint_grpc_events_dropped_total`.
+Telemetry that adds latency to a bid path is worse than no telemetry, and a full
+queue must shed events rather than requests. `vastlint_grpc_events_published_total`
+is the other half: a gap between the two is delivery, a gap between published
+and the request count is a bug here.
+
+**Two things are deliberately manual.** The schema ID is configured rather than
+fetched, because a server that self-registers on startup can quietly create a
+new schema version during a rollback. And registration itself is an operational
+step:
+
+```sh
+curl -X PUT $REGISTRY/config/vastlint.validation.v1-value \
+  -H 'Content-Type: application/json' -d '{"compatibility":"BACKWARD"}'
+
+curl -X POST $REGISTRY/subjects/vastlint.validation.v1-value/versions \
+  -H 'Content-Type: application/vnd.schemaregistry.v1+json' \
+  -d "$(jq -Rs '{schema: .}' < schemas/openadtech/vastlint/v1/validation_event.avsc)"
+```
+
+The `kafka` feature is off by default because `rdkafka` builds a vendored
+librdkafka, a multi-minute C build every developer and CI job would otherwise
+pay for. Without it, events are still built, encoded, and discarded, so the
+encoding path stays exercised in every deployment and a schema problem surfaces
+wherever the server runs. Setting brokers on a binary built without the feature
+is a startup error rather than silent discarding.
+
+**Not tested against a live broker.** No Kafka was available in the environment
+this was written in. The encoding, the framing, the compatibility guarantee, the
+drop policy, and the configuration errors are all covered by tests and verified
+by hand; the producer's behaviour against a real cluster is not.
+
 ## Building
 
 No `protoc` required. Code generation goes through `protox`, a protobuf compiler

--- a/crates/vastlint-grpc/README.md
+++ b/crates/vastlint-grpc/README.md
@@ -156,12 +156,21 @@ Off by default. A topic nobody consumes is pure cost, and turning it on should
 be a decision somebody made rather than something a default did.
 
 ```sh
-VASTLINT_EVENTS_ENABLED=true \
-VASTLINT_SCHEMA_ID=42 \
-VASTLINT_KAFKA_BROKERS=localhost:9092 \
-VASTLINT_KAFKA_TOPIC=vastlint.validation.v1 \
-  cargo run --release -p vastlint-grpc --features kafka
+VASTLINT_EVENTS_ENABLED=true VASTLINT_SCHEMA_ID=42 \
+  cargo run --release -p vastlint-grpc
 ```
+
+**There is no broker client in this build.** Events are built, encoded, framed,
+and discarded, and `vastlint_grpc_events_published_total` counts them. Setting
+`VASTLINT_KAFKA_BROKERS` is a startup error rather than silent discarding.
+
+An `rdkafka` producer lived here behind a feature flag and was removed. CI runs
+`clippy --all-features`, so an optional feature is not optional in CI: every
+platform built a vendored librdkafka on every run and Windows could not build it
+at all. A dependency that breaks a third of the build matrix has to earn its
+place, and one that had never been run against a broker had not. `Sink` is the
+seam; a real producer is one trait method and belongs on a branch with a broker
+to test against.
 
 The motivating case is an SSP that wants a stream of creative rejections rather
 than a request-response call: it has no document to ask about, it wants to know
@@ -204,17 +213,10 @@ curl -X POST $REGISTRY/subjects/vastlint.validation.v1-value/versions \
   -d "$(jq -Rs '{schema: .}' < schemas/openadtech/vastlint/v1/validation_event.avsc)"
 ```
 
-The `kafka` feature is off by default because `rdkafka` builds a vendored
-librdkafka, a multi-minute C build every developer and CI job would otherwise
-pay for. Without it, events are still built, encoded, and discarded, so the
-encoding path stays exercised in every deployment and a schema problem surfaces
-wherever the server runs. Setting brokers on a binary built without the feature
-is a startup error rather than silent discarding.
-
-**Not tested against a live broker.** No Kafka was available in the environment
-this was written in. The encoding, the framing, the compatibility guarantee, the
-drop policy, and the configuration errors are all covered by tests and verified
-by hand; the producer's behaviour against a real cluster is not.
+**What is verified and what is not.** The schema, the Confluent framing, the
+encoding, the BACKWARD compatibility guarantee, the drop policy, and the
+configuration errors are covered by tests and verified by hand. Delivery to a
+real cluster is not implemented here at all, so nothing about it is claimed.
 
 ## Building
 

--- a/crates/vastlint-grpc/README.md
+++ b/crates/vastlint-grpc/README.md
@@ -34,12 +34,30 @@ grpcurl -plaintext -d '{}' localhost:50051 grpc.health.v1.Health/Check
 | `Validate` | Validate one document. |
 | `Fix` | Apply deterministic repairs and return the corrected document. |
 | `ListRules` | The rule catalog, versioned independently of the wire contract. |
-| `ValidateStream` | Bulk validation. **Not implemented yet**, returns `UNIMPLEMENTED`. |
+| `ValidateStream` | Bulk validation over a bidirectional stream. |
 
-`ValidateStream` is deliberately absent rather than naively present: an
-implementation that reads as fast as the client writes has an unbounded buffer,
-which turns a fast producer into server memory exhaustion. It lands with the
-bounded worker channel and the concurrency limiter.
+`ValidateStream` dispatches messages concurrently and answers out of order, so
+callers correlate on `request_id`. A slot on the bounded outbound channel is
+reserved before the next inbound message is read, so a slow reader stalls the
+handler rather than growing a queue behind it. One bad message becomes a
+`StreamError` on its own `request_id` and the stream continues: a single
+document being refused is not a reason to tear down a connection that is
+validating everything else.
+
+Streams are admitted per message, not per call. That is not a detail: the tower
+layer works per HTTP request, and a stream is one request that lives for
+minutes, so treating it like a unary call would hold a concurrency slot for the
+stream's whole lifetime and report the entire lifetime as one latency sample.
+Every stream that ended would drive the adaptive limit down multiplicatively
+until the server was shedding unary callers while doing almost nothing.
+
+**Where the backpressure bound actually is.** The channel bounds the handler's
+queue. Between it and the client sit HTTP/2 flow-control windows, which are
+larger by orders of magnitude. Measured with the defaults, a client that stops
+reading lets roughly 2,800 small responses accumulate before the server stalls,
+and it does stall: progress stops completely and resumes the moment the client
+reads. Size per-stream memory from `VASTLINT_STREAM_WINDOW_BYTES`, not from
+`VASTLINT_STREAM_BUFFER`. See [`tests/backpressure.rs`](tests/backpressure.rs).
 
 ## The contract
 

--- a/crates/vastlint-grpc/README.md
+++ b/crates/vastlint-grpc/README.md
@@ -64,6 +64,63 @@ it can be identified later. The digest is computed over the linked catalog at
 runtime rather than over the rule source at build time, so it still differs if
 rules were compiled out.
 
+## Ingress control
+
+Everything here is off the critical path when the server is healthy and only
+engages under load.
+
+| Control | Behaviour | Default |
+| --- | --- | --- |
+| Adaptive concurrency limit | AIMD over observed latency. Excess is shed with `RESOURCE_EXHAUSTED`, never queued. | on, starting at 32 in [4, 1024] |
+| Per-caller rate limit | Token bucket keyed on a request header. | off |
+| Request size cap | Enforced at the decoder, not after decoding. | 4 MiB |
+| Validation thread pool | The server's real capacity. | one thread per core |
+
+Health and reflection are exempt from shedding. Shedding a health check makes a
+busy instance look dead, so a load balancer pulls it from rotation and moves its
+traffic onto instances that are equally busy.
+
+Rate limiting sits outside the concurrency limiter, so a caller over its
+allowance is refused before it can occupy a concurrency slot. Caller identity
+comes from a header, which is a fairness mechanism and not authentication: the
+failure it prevents is an honest client in a retry storm, not a determined
+attacker.
+
+Configuration is environment-driven and every value is printed at startup, so a
+latency graph can be matched to the settings that produced it. See
+[`src/config.rs`](src/config.rs) for the full list.
+
+## Measured behaviour and SLO
+
+[`LOAD-TEST.md`](LOAD-TEST.md) has the method, the full ramp, and the raw
+numbers. Summary, at offered concurrency well past capacity:
+
+| | limiter off | limiter on |
+| --- | ---: | ---: |
+| p999 at concurrency 128 | 47.42 ms | 7.79 ms |
+| p999 at concurrency 256 | 34.40 ms | 11.28 ms |
+| worst observed | 51.62 ms | 17.57 ms |
+| goodput | baseline | 5 to 7% lower |
+| requests refused | 0% | 2.4% |
+
+Below capacity the two are within noise of each other, which is the point: a
+limiter that taxed the healthy case would not be worth running.
+
+Two things the experiment changed. The original 50ms target latency was reasoned
+from per-tag benchmarks rather than measured, and it turned out to be inert: the
+server's own handling time never approaches it, so the limiter shed 0.02% of
+requests and behaved like no limiter at all. And the real capacity knob was
+tokio's blocking pool, whose 512-thread default is sized for blocking I/O;
+sizing it to the core count raised saturated goodput by roughly 10%.
+
+**SLO**, derived from those measurements rather than asserted:
+
+- 99.9% of requests answered with a verdict or an explicit `RESOURCE_EXHAUSTED`.
+  A refusal a caller can act on is not an outage; a hang is.
+- p99 under 15ms and p999 under 25ms at offered concurrency up to 256, measured
+  client-side.
+- The verdict for a document does not depend on load.
+
 ## Deadlines
 
 The `grpc-timeout` header is honoured. A request whose deadline has already

--- a/crates/vastlint-grpc/README.md
+++ b/crates/vastlint-grpc/README.md
@@ -1,0 +1,86 @@
+# vastlint-grpc
+
+gRPC server for [vastlint](https://vastlint.org). Serves `openadtech.vastlint.v1`
+over HTTP/2, with server reflection and `grpc.health.v1`.
+
+A validator that can only be called from a shell runs in CI and nowhere else.
+This is the transport for callers that need a verdict inside a request budget:
+vastlint benchmarks at 363µs light and 2,104µs heavy per tag, which fits inside
+a bid timeout, and the ARTF specification allows MCP-compatible validators to
+run as containerized services inside SSPs and DSPs.
+
+## Running
+
+```sh
+cargo run -p vastlint-grpc
+# or
+VASTLINT_GRPC_ADDR=0.0.0.0:50051 vastlint-grpc
+```
+
+Reflection is on, so no local copy of the proto is needed:
+
+```sh
+grpcurl -plaintext localhost:50051 list
+grpcurl -plaintext localhost:50051 describe openadtech.vastlint.v1.VastlintService
+grpcurl -plaintext -d '{"document":"<VAST version=\"4.1\"></VAST>"}' \
+  localhost:50051 openadtech.vastlint.v1.VastlintService/Validate
+grpcurl -plaintext -d '{}' localhost:50051 grpc.health.v1.Health/Check
+```
+
+## RPCs
+
+| RPC | Purpose |
+| --- | --- |
+| `Validate` | Validate one document. |
+| `Fix` | Apply deterministic repairs and return the corrected document. |
+| `ListRules` | The rule catalog, versioned independently of the wire contract. |
+| `ValidateStream` | Bulk validation. **Not implemented yet**, returns `UNIMPLEMENTED`. |
+
+`ValidateStream` is deliberately absent rather than naively present: an
+implementation that reads as fast as the client writes has an unbounded buffer,
+which turns a fast producer into server memory exhaustion. It lands with the
+bounded worker channel and the concurrency limiter.
+
+## The contract
+
+Lives in [`proto/openadtech/vastlint/v1/vastlint.proto`](../../proto/openadtech/vastlint/v1/vastlint.proto),
+not generated from the Rust types. `buf breaking` runs against `main` on every
+pull request, so backward compatibility is enforced by CI rather than by review.
+
+Two decisions the file explains in more detail:
+
+**Rule IDs are strings, not a proto enum.** The catalog went from 108 rules in
+April 2026 to 222 in August. Binding a fast-moving catalog to a slow-moving wire
+contract makes every new rule a contract change. The cost is no compile-time
+checking of rule IDs, bought back by a stability policy: IDs are permanent and
+never reused, rules deprecate rather than disappear, and `ListRules` is the
+discovery mechanism. Unknown rule IDs in `rule_overrides` are rejected with
+`INVALID_ARGUMENT` rather than ignored, because a typo that silently disables
+nothing is indistinguishable from a rule that never fires.
+
+**Every response carries `Provenance`:** catalog version, catalog content
+digest, and engine version. A verdict is only reproducible if the ruleset behind
+it can be identified later. The digest is computed over the linked catalog at
+runtime rather than over the rule source at build time, so it still differs if
+rules were compiled out.
+
+## Deadlines
+
+The `grpc-timeout` header is honoured. A request whose deadline has already
+expired is refused before any work starts.
+
+One limitation worth stating: `spawn_blocking` tasks cannot be cancelled, so
+when a deadline fires the caller gets `DEADLINE_EXCEEDED` immediately but the
+worker thread runs to completion. For vastlint that is bounded and short. It is
+still real, and it is why capacity protection needs a concurrency limit rather
+than deadlines alone. A deadline stops the waiting, not the working.
+
+## Building
+
+No `protoc` required. Code generation goes through `protox`, a protobuf compiler
+written in Rust, so `cargo install vastlint-grpc` works without a system
+dependency that is not declared in `Cargo.toml`.
+
+## License
+
+Apache-2.0.

--- a/crates/vastlint-grpc/build.rs
+++ b/crates/vastlint-grpc/build.rs
@@ -1,0 +1,47 @@
+//! Generates the `openadtech.vastlint.v1` bindings and the encoded file
+//! descriptor set.
+//!
+//! The descriptor set is what server reflection serves, so `grpcurl` can
+//! describe and call this server without a local copy of the proto. Same
+//! approach as the reflection support added to the ARTF Rust reference
+//! implementation.
+//!
+//! Compilation goes through `protox`, a protobuf compiler written in Rust,
+//! rather than shelling out to `protoc`. That is not a style preference. The
+//! default `prost-build` path requires a `protoc` binary on `PATH` at build
+//! time, which would mean every CI runner across three operating systems needs
+//! a new install step, and, worse, anyone running `cargo install vastlint-grpc`
+//! from crates.io would need it too. A validator that will not build without an
+//! undeclared system dependency is not one distribution channel, it is a
+//! support burden.
+
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../proto");
+    let proto = proto_root.join("openadtech/vastlint/v1/vastlint.proto");
+    let descriptor_set = PathBuf::from(std::env::var("OUT_DIR")?).join("vastlint_descriptor.bin");
+
+    // Rebuild when the contract changes. Without this, editing the proto leaves
+    // a stale generated module in place and the mismatch surfaces as a
+    // confusing type error somewhere else.
+    println!("cargo:rerun-if-changed={}", proto.display());
+
+    let file_descriptors = protox::compile([&proto], [&proto_root])?;
+
+    // Written by hand rather than via `file_descriptor_set_path`, because that
+    // option belongs to the protoc path we are deliberately not taking.
+    std::fs::write(&descriptor_set, {
+        use prost::Message;
+        file_descriptors.encode_to_vec()
+    })?;
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        // The client is generated too, so integration tests exercise the real
+        // wire path rather than calling the service implementation directly.
+        .build_client(true)
+        .compile_fds(file_descriptors)?;
+
+    Ok(())
+}

--- a/crates/vastlint-grpc/examples/loadgen.rs
+++ b/crates/vastlint-grpc/examples/loadgen.rs
@@ -1,0 +1,532 @@
+//! Load harness for the adaptive concurrency limiter.
+//!
+//! Exists because phase 3 without a measurement is a claim. The server can
+//! expose a shed counter and a latency histogram and still be telling nobody
+//! anything: the question is whether the limiter actually bounds tail latency
+//! when offered load exceeds capacity, and the only way to know is to offer
+//! more load than capacity and look.
+//!
+//! ## What this measures
+//!
+//! A closed-loop ramp. At each level, N workers each issue `Validate` calls
+//! back to back for a fixed window, so offered concurrency is exactly N. That
+//! is the right shape for this question: as N passes what the server can
+//! actually do, an unprotected server's latency grows without bound because the
+//! excess sits in queues, while a protected one refuses the excess and keeps
+//! its served requests fast.
+//!
+//! Latency is measured client-side, which is the number that matters. A server
+//! that reports a healthy internal p99 while callers wait in a connection
+//! backlog is reporting on the wrong thing.
+//!
+//! ## What it does not measure
+//!
+//! Throughput here is not a benchmark of the validator. The client, the server,
+//! and the load generator share one machine, so absolute numbers are worth less
+//! than the comparison between two runs of the same shape on the same box. The
+//! comparison is the point.
+//!
+//! ```text
+//! cargo run --release --example loadgen -- --label with-limiter
+//! cargo run --release --example loadgen -- --target http://127.0.0.1:50051 --csv out.csv
+//! ```
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use hdrhistogram::Histogram;
+use tonic::transport::Channel;
+use tonic::Code;
+use vastlint_grpc::proto::vastlint_service_client::VastlintServiceClient;
+use vastlint_grpc::proto::ValidateRequest;
+
+/// Concurrency levels to walk through.
+///
+/// Doubling rather than stepping, because the interesting behaviour is a knee
+/// and a linear ramp spends most of its time far away from it.
+const LEVELS: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128, 256];
+
+/// How long to hold each level.
+const DEFAULT_WINDOW: Duration = Duration::from_secs(3);
+
+/// Discarded before measurement starts at each level, so the numbers describe
+/// steady state rather than the moment the limiter was still adapting.
+const WARMUP: Duration = Duration::from_millis(500);
+
+struct Args {
+    target: String,
+    label: String,
+    window: Duration,
+    csv: Option<String>,
+    /// Concurrency levels to run. Defaults to the full ramp.
+    levels: Vec<usize>,
+}
+
+fn parse_args() -> Args {
+    let mut args = Args {
+        target: "http://127.0.0.1:50051".to_string(),
+        label: "run".to_string(),
+        window: DEFAULT_WINDOW,
+        csv: None,
+        levels: LEVELS.to_vec(),
+    };
+
+    let mut argv = std::env::args().skip(1);
+    while let Some(flag) = argv.next() {
+        match flag.as_str() {
+            "--target" => args.target = argv.next().expect("--target needs a value"),
+            "--label" => args.label = argv.next().expect("--label needs a value"),
+            "--csv" => args.csv = Some(argv.next().expect("--csv needs a value")),
+            // Useful for isolating one point on the curve, for example when
+            // comparing client-observed latency against the server's own
+            // histogram at a single concurrency.
+            "--levels" => {
+                args.levels = argv
+                    .next()
+                    .expect("--levels needs a comma-separated list")
+                    .split(',')
+                    .map(|level| level.trim().parse().expect("--levels must be numbers"))
+                    .collect();
+            }
+            "--window-secs" => {
+                let secs: u64 = argv
+                    .next()
+                    .expect("--window-secs needs a value")
+                    .parse()
+                    .expect("--window-secs must be a number");
+                args.window = Duration::from_secs(secs);
+            }
+            other => panic!("unknown flag {other}"),
+        }
+    }
+
+    args
+}
+
+/// A light tag: one ad, complete and realistic.
+///
+/// Not a minimal tag. A stripped-down document validates in tens of
+/// microseconds, which would put the corpus spread near 50x and make the whole
+/// ramp unreadable. Real single-ad traffic carries quartile tracking and
+/// several renditions, so that is what this carries, landing near the published
+/// 363µs light benchmark.
+fn light_document() -> String {
+    let mut xml = String::from(
+        r#"<VAST version="4.1"><Ad id="1"><InLine><AdSystem version="1.0">Example</AdSystem><AdTitle>Example Ad</AdTitle><AdServingId>serving-1</AdServingId><Advertiser>Example Brand</Advertiser><Pricing model="CPM" currency="USD">15.00</Pricing>"#,
+    );
+
+    for tracker in 0..3 {
+        xml.push_str(&format!(
+            r#"<Impression id="imp-{tracker}"><![CDATA[https://t.example.com/i?n={tracker}]]></Impression>"#
+        ));
+    }
+
+    xml.push_str(
+        r#"<Creatives><Creative id="c1" sequence="1"><UniversalAdId idRegistry="ad-id.org">UID-0001</UniversalAdId><Linear><Duration>00:00:15</Duration><TrackingEvents>"#,
+    );
+    for event in [
+        "start",
+        "firstQuartile",
+        "midpoint",
+        "thirdQuartile",
+        "complete",
+    ] {
+        xml.push_str(&format!(
+            r#"<Tracking event="{event}"><![CDATA[https://t.example.com/{event}]]></Tracking>"#
+        ));
+    }
+    xml.push_str("</TrackingEvents><MediaFiles>");
+    for (width, height) in [(640, 360), (1280, 720), (1920, 1080)] {
+        xml.push_str(&format!(
+            r#"<MediaFile delivery="progressive" type="video/mp4" width="{width}" height="{height}" bitrate="2000"><![CDATA[https://cdn.example.com/a-{width}.mp4]]></MediaFile>"#
+        ));
+    }
+    xml.push_str(
+        r#"</MediaFiles><VideoClicks><ClickThrough><![CDATA[https://example.com/landing]]></ClickThrough><ClickTracking><![CDATA[https://t.example.com/click]]></ClickTracking></VideoClicks></Linear></Creative></Creatives></InLine></Ad></VAST>"#,
+    );
+
+    xml
+}
+
+/// A heavy tag: a pod with several creatives and full tracking.
+///
+/// The mix matters, and so does its spread. A uniform corpus of light tags
+/// would never saturate the server from one machine. But an absurdly heavy one
+/// is just as useless in the other direction: the first version of this
+/// generator built a 40-ad document that took 340ms, so p999 measured "did this
+/// request draw the heavy document" and said nothing about queueing at all. The
+/// tail has to come from load, not from corpus variance.
+///
+/// Sized to the *ratio* of the published per-tag benchmarks, 363µs light to
+/// 2,104µs heavy, roughly 6x. The absolute numbers are not reproduced and are
+/// not meant to be: they depend on the machine. What has to hold is that the
+/// heavy document is expensive enough to saturate the server and cheap enough
+/// that drawing it is not itself the tail. `calibrate` prints what it actually
+/// costs on the machine under test, so a drift here is visible rather than
+/// assumed.
+fn heavy_document() -> String {
+    let mut xml = String::from(r#"<VAST version="4.2">"#);
+
+    for ad in 0..1 {
+        xml.push_str(&format!(r#"<Ad id="{ad}" sequence="{}"><InLine>"#, ad + 1));
+        xml.push_str("<AdSystem>Example</AdSystem><AdTitle>Heavy</AdTitle>");
+        xml.push_str(&format!("<AdServingId>serving-{ad}</AdServingId>"));
+
+        for tracker in 0..10 {
+            xml.push_str(&format!(
+                r#"<Impression id="i{tracker}"><![CDATA[https://t.example.com/i?ad={ad}&n={tracker}]]></Impression>"#
+            ));
+        }
+
+        xml.push_str("<Creatives>");
+        for creative in 0..4 {
+            xml.push_str(&format!(
+                r#"<Creative id="c{creative}"><UniversalAdId idRegistry="ad-id.org">UID-{ad}-{creative}</UniversalAdId><Linear><Duration>00:00:30</Duration><TrackingEvents>"#
+            ));
+            for event in [
+                "start",
+                "firstQuartile",
+                "midpoint",
+                "thirdQuartile",
+                "complete",
+                "pause",
+                "resume",
+                "mute",
+            ] {
+                xml.push_str(&format!(
+                    r#"<Tracking event="{event}"><![CDATA[https://t.example.com/{event}?a={ad}]]></Tracking>"#
+                ));
+            }
+            xml.push_str("</TrackingEvents><MediaFiles>");
+            for media in 0..4 {
+                xml.push_str(&format!(
+                    r#"<MediaFile delivery="progressive" type="video/mp4" width="1920" height="1080"><![CDATA[https://cdn.example.com/{ad}-{creative}-{media}.mp4]]></MediaFile>"#
+                ));
+            }
+            xml.push_str("</MediaFiles></Linear></Creative>");
+        }
+        xml.push_str("</Creatives></InLine></Ad>");
+    }
+
+    xml.push_str("</VAST>");
+    xml
+}
+
+/// One corpus entry, with its class recorded rather than inferred.
+///
+/// Classifying by document length worked until the light tag grew realistic
+/// enough to cross the threshold, at which point the calibration output would
+/// have quietly reported ten heavy documents and no light ones.
+struct Document {
+    heavy: bool,
+    xml: String,
+}
+
+#[derive(Default)]
+struct Counts {
+    ok: AtomicU64,
+    shed: AtomicU64,
+    other: AtomicU64,
+}
+
+struct LevelResult {
+    concurrency: usize,
+    ok: u64,
+    shed: u64,
+    other: u64,
+    goodput: f64,
+    p50_ms: f64,
+    p99_ms: f64,
+    p999_ms: f64,
+    max_ms: f64,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = parse_args();
+
+    // One 80/20 light-to-heavy corpus, built once. Rebuilding per request would
+    // measure string formatting as much as validation.
+    let corpus: Arc<Vec<Document>> = Arc::new(
+        (0..10)
+            .map(|i| {
+                if i < 8 {
+                    Document {
+                        heavy: false,
+                        xml: light_document(),
+                    }
+                } else {
+                    Document {
+                        heavy: true,
+                        xml: heavy_document(),
+                    }
+                }
+            })
+            .collect(),
+    );
+
+    println!("target      {}", args.target);
+    println!("label       {}", args.label);
+    println!(
+        "window      {:?} per level, after {WARMUP:?} warm-up",
+        args.window
+    );
+    println!(
+        "corpus      {} documents, {} light and {} heavy",
+        corpus.len(),
+        corpus.iter().filter(|d| !d.heavy).count(),
+        corpus.iter().filter(|d| d.heavy).count()
+    );
+    calibrate(&corpus);
+    println!();
+
+    let mut results = Vec::new();
+
+    for &concurrency in &args.levels {
+        let result = run_level(&args, Arc::clone(&corpus), concurrency).await?;
+        print_row(&result, results.is_empty());
+        results.push(result);
+    }
+
+    if let Some(path) = &args.csv {
+        write_csv(path, &args.label, &results)?;
+        println!("\nwrote {path}");
+    }
+
+    summarise(&args.label, &results);
+
+    Ok(())
+}
+
+/// Measures what the corpus costs locally, with no transport involved.
+///
+/// This is the denominator for everything that follows. Without it, a p999 of
+/// 40ms could be queueing or could be one expensive document, and there would
+/// be no way to tell from the ramp alone. It also catches the failure that
+/// broke the first version of this harness: a corpus whose spread is so wide
+/// that tail latency tracks document choice rather than load.
+fn calibrate(corpus: &[Document]) {
+    let mut light = Vec::new();
+    let mut heavy = Vec::new();
+
+    for document in corpus {
+        // Warm the allocator and any lazily built state first, so the first
+        // document measured is not also paying for initialisation.
+        let _ = vastlint_core::validate(&document.xml);
+
+        let mut samples = Vec::new();
+        for _ in 0..20 {
+            let started = Instant::now();
+            let _ = vastlint_core::validate(&document.xml);
+            samples.push(started.elapsed().as_secs_f64() * 1_000.0);
+        }
+        samples.sort_by(|a, b| a.partial_cmp(b).expect("no NaN in timings"));
+        let median = samples[samples.len() / 2];
+
+        if document.heavy {
+            heavy.push(median);
+        } else {
+            light.push(median);
+        }
+    }
+
+    let mean = |values: &[f64]| values.iter().sum::<f64>() / values.len().max(1) as f64;
+    let light_ms = mean(&light);
+    let heavy_ms = mean(&heavy);
+
+    println!(
+        "cost        light {light_ms:.3} ms, heavy {heavy_ms:.3} ms, spread {:.1}x (measured here, no transport)",
+        heavy_ms / light_ms.max(f64::MIN_POSITIVE)
+    );
+
+    // A corpus whose slowest document is orders of magnitude past its fastest
+    // makes the tail unreadable: p999 becomes a statement about which document
+    // was drawn. Warn rather than fail, because the run is still informative if
+    // the reader knows.
+    if heavy_ms / light_ms.max(f64::MIN_POSITIVE) > 20.0 {
+        println!(
+            "            WARNING: spread is wide enough that tail latency may track document \
+             choice rather than load"
+        );
+    }
+}
+
+async fn run_level(
+    args: &Args,
+    corpus: Arc<Vec<Document>>,
+    concurrency: usize,
+) -> Result<LevelResult, Box<dyn std::error::Error>> {
+    let counts = Arc::new(Counts::default());
+    // 3 significant figures out to a minute. Enough resolution for a p999 in
+    // the microsecond range without an enormous histogram.
+    let histogram: Arc<std::sync::Mutex<Histogram<u64>>> = Arc::new(std::sync::Mutex::new(
+        Histogram::new_with_bounds(1, 60_000_000, 3)?,
+    ));
+
+    let deadline = Instant::now() + WARMUP + args.window;
+    let measure_from = Instant::now() + WARMUP;
+
+    let mut workers = Vec::with_capacity(concurrency);
+    for worker in 0..concurrency {
+        // A channel per worker rather than a shared one. tonic multiplexes over
+        // HTTP/2, so a single channel would make the client's own stream
+        // concurrency limit part of what is being measured.
+        let channel = Channel::from_shared(args.target.clone())?.connect().await?;
+        let mut client = VastlintServiceClient::new(channel);
+
+        let counts = Arc::clone(&counts);
+        let histogram = Arc::clone(&histogram);
+        let corpus = Arc::clone(&corpus);
+
+        workers.push(tokio::spawn(async move {
+            let mut index = worker;
+
+            while Instant::now() < deadline {
+                let document = corpus[index % corpus.len()].xml.clone();
+                index += 1;
+
+                let started = Instant::now();
+                let outcome = client
+                    .validate(ValidateRequest {
+                        document,
+                        context: None,
+                    })
+                    .await;
+                let elapsed = started.elapsed();
+
+                let measured = started >= measure_from;
+
+                match outcome {
+                    Ok(_) => {
+                        if measured {
+                            counts.ok.fetch_add(1, Ordering::Relaxed);
+                            let micros = elapsed.as_micros().max(1) as u64;
+                            let _ = histogram.lock().unwrap().record(micros);
+                        }
+                    }
+                    Err(status) if status.code() == Code::ResourceExhausted => {
+                        if measured {
+                            counts.shed.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                    Err(_) => {
+                        if measured {
+                            counts.other.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+            }
+        }));
+    }
+
+    for worker in workers {
+        worker.await?;
+    }
+
+    let histogram = histogram.lock().unwrap();
+    let ok = counts.ok.load(Ordering::Relaxed);
+
+    Ok(LevelResult {
+        concurrency,
+        ok,
+        shed: counts.shed.load(Ordering::Relaxed),
+        other: counts.other.load(Ordering::Relaxed),
+        // Goodput, not throughput: shed responses are fast and counting them
+        // would make an overloaded server look productive.
+        goodput: ok as f64 / args.window.as_secs_f64(),
+        p50_ms: histogram.value_at_quantile(0.50) as f64 / 1_000.0,
+        p99_ms: histogram.value_at_quantile(0.99) as f64 / 1_000.0,
+        p999_ms: histogram.value_at_quantile(0.999) as f64 / 1_000.0,
+        max_ms: histogram.max() as f64 / 1_000.0,
+    })
+}
+
+fn print_row(result: &LevelResult, first_row: bool) {
+    if first_row {
+        println!(
+            "{:>5}  {:>9}  {:>8}  {:>8}  {:>8}  {:>8}  {:>7}  {:>7}",
+            "conc", "goodput/s", "p50 ms", "p99 ms", "p999 ms", "max ms", "ok", "shed"
+        );
+        println!("{}", "-".repeat(76));
+    }
+
+    println!(
+        "{:>5}  {:>9.0}  {:>8.2}  {:>8.2}  {:>8.2}  {:>8.2}  {:>7}  {:>7}{}",
+        result.concurrency,
+        result.goodput,
+        result.p50_ms,
+        result.p99_ms,
+        result.p999_ms,
+        result.max_ms,
+        result.ok,
+        result.shed,
+        if result.other > 0 {
+            format!("  ({} errors)", result.other)
+        } else {
+            String::new()
+        }
+    );
+}
+
+fn write_csv(
+    path: &str,
+    label: &str,
+    results: &[LevelResult],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut csv = String::from(
+        "label,concurrency,goodput_per_s,p50_ms,p99_ms,p999_ms,max_ms,ok,shed,errors\n",
+    );
+
+    for result in results {
+        csv.push_str(&format!(
+            "{label},{},{:.1},{:.3},{:.3},{:.3},{:.3},{},{},{}\n",
+            result.concurrency,
+            result.goodput,
+            result.p50_ms,
+            result.p99_ms,
+            result.p999_ms,
+            result.max_ms,
+            result.ok,
+            result.shed,
+            result.other
+        ));
+    }
+
+    std::fs::write(path, csv)?;
+    Ok(())
+}
+
+/// Prints the one comparison the run exists to produce.
+fn summarise(label: &str, results: &[LevelResult]) {
+    let Some(first) = results.first() else { return };
+    let Some(last) = results.last() else { return };
+
+    println!();
+    println!("{label}:");
+    println!(
+        "  p999 went from {:.2} ms at concurrency {} to {:.2} ms at concurrency {} ({:.1}x)",
+        first.p999_ms,
+        first.concurrency,
+        last.p999_ms,
+        last.concurrency,
+        last.p999_ms / first.p999_ms.max(0.001),
+    );
+
+    let shed: u64 = results.iter().map(|r| r.shed).sum();
+    let ok: u64 = results.iter().map(|r| r.ok).sum();
+    if shed == 0 {
+        println!("  nothing was shed: every request was admitted");
+    } else {
+        println!(
+            "  {shed} of {} requests shed ({:.1}%)",
+            shed + ok,
+            100.0 * shed as f64 / (shed + ok) as f64
+        );
+    }
+
+    let errors: u64 = results.iter().map(|r| r.other).sum();
+    if errors > 0 {
+        println!("  {errors} requests failed for other reasons, which is worth explaining before trusting the rest");
+    }
+}

--- a/crates/vastlint-grpc/src/config.rs
+++ b/crates/vastlint-grpc/src/config.rs
@@ -1,0 +1,361 @@
+//! Server configuration, read from the environment.
+//!
+//! Every knob has a default that is safe to run with, and every default is
+//! stated here rather than scattered across the code. The limiter can be turned
+//! off entirely, which exists so the load harness can measure the same server
+//! with and without it: a shedding policy nobody has measured is a claim, not a
+//! result.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+/// Everything the server reads from the environment at startup.
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub addr: SocketAddr,
+    /// `None` disables the metrics endpoint entirely.
+    pub metrics_addr: Option<SocketAddr>,
+    pub limit: LimitConfig,
+    pub rate_limit: RateLimitConfig,
+    /// Largest request body the server will decode.
+    pub max_message_bytes: usize,
+    /// Header carrying the caller identity used for rate limiting.
+    pub caller_header: String,
+    /// Async runtime threads. `None` uses tokio's default of one per core.
+    pub worker_threads: Option<usize>,
+    /// Threads available to run validation.
+    ///
+    /// This is the server's real capacity, and it is worth being explicit about
+    /// why. Validation is CPU-bound and runs on tokio's blocking pool, whose
+    /// default ceiling is 512 threads. That default is sized for blocking I/O,
+    /// where threads spend their lives waiting. Here they never wait, so 512 of
+    /// them on a machine with a dozen cores does not add throughput: it adds
+    /// context switching and turns what should be a queue into a stampede.
+    /// Sized to the core count instead, so concurrency past capacity shows up
+    /// as a decision the limiter gets to make rather than as latency nobody
+    /// chose.
+    pub blocking_threads: usize,
+}
+
+/// Adaptive concurrency limiter settings.
+#[derive(Debug, Clone)]
+pub struct LimitConfig {
+    /// When false, no concurrency limiting and no shedding happens at all. The
+    /// A side of the A/B run.
+    pub enabled: bool,
+    pub initial: usize,
+    pub min: usize,
+    pub max: usize,
+    /// Latency above which a completed request counts as evidence of overload.
+    /// Not a request timeout: the request still succeeds, it just votes to
+    /// lower the limit.
+    pub target_latency: Duration,
+    /// Multiplicative decrease factor applied on an overload signal.
+    pub backoff_ratio: f64,
+}
+
+/// Per-caller token bucket settings.
+///
+/// Both fields default to zero, which disables the limiter. A rate limit with a
+/// number nobody chose is worse than none: it either never fires, or it fires on
+/// a legitimate caller who had no way to know the number.
+#[derive(Debug, Clone, Default)]
+pub struct RateLimitConfig {
+    /// Sustained requests per second allowed per caller. 0 disables.
+    pub per_second: u32,
+    /// Burst capacity. Defaults to one second of sustained rate.
+    pub burst: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            addr: "0.0.0.0:50051".parse().expect("valid default addr"),
+            metrics_addr: Some("0.0.0.0:9090".parse().expect("valid default metrics addr")),
+            limit: LimitConfig::default(),
+            rate_limit: RateLimitConfig::default(),
+            // 4 MiB, matching tonic's own default. A VAST tag is kilobytes; a
+            // 40 MB wrapper chain is an attack, not a creative.
+            max_message_bytes: 4 * 1024 * 1024,
+            caller_header: "x-vastlint-caller".to_string(),
+            worker_threads: None,
+            blocking_threads: default_blocking_threads(),
+        }
+    }
+}
+
+/// One validation thread per core.
+///
+/// Falls back to 4 when the core count is unavailable, which is a number
+/// chosen to be small enough not to thrash a constrained container and large
+/// enough that the server is not trivially serial.
+fn default_blocking_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(4)
+}
+
+impl Default for LimitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            // Starts optimistic. AIMD finds the real ceiling within a few
+            // seconds of load, and starting low would shed traffic the server
+            // could have served while it climbed.
+            initial: 32,
+            // Never shed everything. A server that has driven its own limit to
+            // zero cannot recover, because it needs completed requests to
+            // produce the evidence that would raise the limit again.
+            min: 4,
+            max: 1024,
+            // Calibrate this per deployment. See `LOAD-TEST.md`.
+            //
+            // The first value here was 50ms, reasoned from the per-tag
+            // benchmarks as "twenty-five heavy tags of headroom". Measurement
+            // showed that was inert: under saturation the server's own handling
+            // time stays under 1ms at p99, so a 50ms trigger never fired and the
+            // limiter shed 0.02% of requests while behaving like no limiter at
+            // all. 2ms was chosen from the measured distribution instead, and
+            // the difference between a number that engages and one that does not
+            // is the entire value of having run the experiment.
+            target_latency: Duration::from_millis(2),
+            // 0.9 rather than the more common 0.5. Halving is right when a
+            // breach means a hard dependency failed; here it means the box is
+            // busy, and overreacting turns a latency blip into a throughput
+            // collapse.
+            backoff_ratio: 0.9,
+        }
+    }
+}
+
+impl Config {
+    /// Reads configuration from the environment, falling back to defaults.
+    ///
+    /// A malformed value is an error rather than a silent fallback. Starting
+    /// with a default limit because someone typo'd the override is how a server
+    /// ends up unprotected while its operator believes otherwise.
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let defaults = Self::default();
+
+        let metrics_addr = match std::env::var("VASTLINT_METRICS_ADDR") {
+            Err(_) => defaults.metrics_addr,
+            // An explicitly empty value disables the endpoint. Useful when
+            // something else already occupies the port.
+            Ok(raw) if raw.trim().is_empty() => None,
+            Ok(raw) => Some(parse("VASTLINT_METRICS_ADDR", &raw)?),
+        };
+
+        let per_second = env_parse("VASTLINT_RATE_LIMIT_RPS", defaults.rate_limit.per_second)?;
+        let burst = match std::env::var("VASTLINT_RATE_LIMIT_BURST") {
+            Ok(raw) => parse("VASTLINT_RATE_LIMIT_BURST", &raw)?,
+            // One second of sustained rate. Enough to absorb a caller that
+            // batches its requests without letting it sustain the burst rate.
+            Err(_) => per_second,
+        };
+
+        let config = Self {
+            addr: match std::env::var("VASTLINT_GRPC_ADDR") {
+                Ok(raw) => parse("VASTLINT_GRPC_ADDR", &raw)?,
+                Err(_) => defaults.addr,
+            },
+            metrics_addr,
+            limit: LimitConfig {
+                enabled: env_flag("VASTLINT_LIMIT_ENABLED", defaults.limit.enabled)?,
+                initial: env_parse("VASTLINT_LIMIT_INITIAL", defaults.limit.initial)?,
+                min: env_parse("VASTLINT_LIMIT_MIN", defaults.limit.min)?,
+                max: env_parse("VASTLINT_LIMIT_MAX", defaults.limit.max)?,
+                target_latency: Duration::from_millis(env_parse(
+                    "VASTLINT_LIMIT_TARGET_LATENCY_MS",
+                    defaults.limit.target_latency.as_millis() as u64,
+                )?),
+                backoff_ratio: env_parse("VASTLINT_LIMIT_BACKOFF", defaults.limit.backoff_ratio)?,
+            },
+            rate_limit: RateLimitConfig { per_second, burst },
+            max_message_bytes: env_parse("VASTLINT_MAX_MESSAGE_BYTES", defaults.max_message_bytes)?,
+            caller_header: std::env::var("VASTLINT_CALLER_HEADER")
+                .unwrap_or(defaults.caller_header),
+            worker_threads: match std::env::var("VASTLINT_WORKER_THREADS") {
+                Ok(raw) => Some(parse("VASTLINT_WORKER_THREADS", &raw)?),
+                Err(_) => defaults.worker_threads,
+            },
+            blocking_threads: env_parse("VASTLINT_BLOCKING_THREADS", defaults.blocking_threads)?,
+        };
+
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Rejects combinations that would leave the server in a state it cannot
+    /// recover from, rather than discovering them under load.
+    fn validate(&self) -> Result<(), ConfigError> {
+        if self.limit.min == 0 {
+            return Err(ConfigError::Invalid {
+                name: "VASTLINT_LIMIT_MIN",
+                reason: "must be at least 1: a limit of zero sheds every request, including the \
+                         ones whose completion would raise the limit again",
+            });
+        }
+
+        if self.limit.min > self.limit.max {
+            return Err(ConfigError::Invalid {
+                name: "VASTLINT_LIMIT_MIN",
+                reason: "must not exceed VASTLINT_LIMIT_MAX",
+            });
+        }
+
+        if !(0.0..1.0).contains(&self.limit.backoff_ratio) {
+            return Err(ConfigError::Invalid {
+                name: "VASTLINT_LIMIT_BACKOFF",
+                reason: "must be in [0.0, 1.0): 1.0 or above never decreases the limit, so \
+                         the limiter would only ever grow",
+            });
+        }
+
+        if self.max_message_bytes == 0 {
+            return Err(ConfigError::Invalid {
+                name: "VASTLINT_MAX_MESSAGE_BYTES",
+                reason: "must be at least 1",
+            });
+        }
+
+        if self.blocking_threads == 0 {
+            return Err(ConfigError::Invalid {
+                name: "VASTLINT_BLOCKING_THREADS",
+                reason: "must be at least 1, or no validation can run at all",
+            });
+        }
+
+        if self.worker_threads == Some(0) {
+            return Err(ConfigError::Invalid {
+                name: "VASTLINT_WORKER_THREADS",
+                reason: "must be at least 1",
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigError {
+    Unparseable {
+        name: &'static str,
+        value: String,
+    },
+    Invalid {
+        name: &'static str,
+        reason: &'static str,
+    },
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unparseable { name, value } => {
+                write!(f, "{name} is not a valid value: {value:?}")
+            }
+            Self::Invalid { name, reason } => write!(f, "{name} {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+fn parse<T: std::str::FromStr>(name: &'static str, raw: &str) -> Result<T, ConfigError> {
+    raw.trim().parse().map_err(|_| ConfigError::Unparseable {
+        name,
+        value: raw.to_string(),
+    })
+}
+
+fn env_parse<T: std::str::FromStr>(name: &'static str, fallback: T) -> Result<T, ConfigError> {
+    match std::env::var(name) {
+        Ok(raw) => parse(name, &raw),
+        Err(_) => Ok(fallback),
+    }
+}
+
+fn env_flag(name: &'static str, fallback: bool) -> Result<bool, ConfigError> {
+    match std::env::var(name) {
+        Err(_) => Ok(fallback),
+        Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Ok(true),
+            "0" | "false" | "no" | "off" => Ok(false),
+            _ => Err(ConfigError::Unparseable { name, value: raw }),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_valid() {
+        Config::default().validate().expect("defaults validate");
+    }
+
+    /// The limiter needs completed requests to raise its own limit, so a floor
+    /// of zero is an absorbing state: once there, no request is admitted, so no
+    /// evidence arrives, so the limit never rises.
+    #[test]
+    fn a_minimum_limit_of_zero_is_rejected() {
+        let mut config = Config::default();
+        config.limit.min = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn an_inverted_limit_range_is_rejected() {
+        let mut config = Config::default();
+        config.limit.min = 100;
+        config.limit.max = 10;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn a_backoff_ratio_that_never_decreases_is_rejected() {
+        let mut config = Config::default();
+        config.limit.backoff_ratio = 1.0;
+        assert!(config.validate().is_err());
+
+        config.limit.backoff_ratio = 1.5;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn a_backoff_ratio_of_zero_is_allowed_if_aggressive() {
+        let mut config = Config::default();
+        config.limit.backoff_ratio = 0.0;
+        // Collapses straight to the floor on any overload signal. Extreme, but
+        // it is a choice an operator is entitled to make.
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn a_server_with_no_validation_threads_is_rejected() {
+        let config = Config {
+            blocking_threads: 0,
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    /// The blocking pool is the server's real capacity, so it must not silently
+    /// inherit tokio's I/O-shaped default of 512 threads for CPU-bound work.
+    #[test]
+    fn the_default_validation_pool_is_sized_to_the_machine() {
+        let config = Config::default();
+        assert!(config.blocking_threads >= 1);
+        assert!(
+            config.blocking_threads <= 256,
+            "a CPU-bound pool should track cores, not tokio's blocking default"
+        );
+    }
+
+    #[test]
+    fn flags_accept_the_usual_spellings() {
+        assert!(env_flag("VASTLINT_TEST_MISSING_FLAG", true).unwrap());
+        assert!(!env_flag("VASTLINT_TEST_MISSING_FLAG", false).unwrap());
+    }
+}

--- a/crates/vastlint-grpc/src/config.rs
+++ b/crates/vastlint-grpc/src/config.rs
@@ -23,6 +23,35 @@ pub struct Config {
     pub caller_header: String,
     /// Async runtime threads. `None` uses tokio's default of one per core.
     pub worker_threads: Option<usize>,
+    /// HTTP/2 receive window per stream, in bytes. `None` keeps tonic's default.
+    ///
+    /// This, not [`Self::stream_buffer`], is what actually bounds how far a
+    /// streaming server runs ahead of a client that has stopped reading. The
+    /// channel bounds the handler's own queue; the transport window bounds
+    /// everything between the handler and the socket, and it is the larger of
+    /// the two by orders of magnitude. Measured with the defaults, a client that
+    /// stops reading lets roughly 2,800 small responses accumulate before the
+    /// server stalls. See `tests/backpressure.rs`.
+    ///
+    /// Left at the default because shrinking it costs throughput on every
+    /// stream to bound memory that is, at a few megabytes per stream, usually
+    /// affordable. Exposed because "usually" is doing real work in that
+    /// sentence, and an operator running thousands of concurrent streams on a
+    /// small container needs the knob.
+    pub stream_window_bytes: Option<u32>,
+    /// HTTP/2 receive window per connection, in bytes. `None` keeps tonic's
+    /// default. Bounds the sum across all streams sharing one connection.
+    pub connection_window_bytes: Option<u32>,
+    /// In-flight messages permitted on one `ValidateStream` call.
+    ///
+    /// This is the bound that makes streaming backpressure real. The handler
+    /// reserves a slot on the outbound channel before reading the next inbound
+    /// message, so when the buffer is full it stops reading. That stall
+    /// propagates into HTTP/2 flow control and the client's writes block, which
+    /// is the correct answer to a producer faster than the server. An unbounded
+    /// buffer would accept the whole firehose into memory and call it
+    /// throughput.
+    pub stream_buffer: usize,
     /// Threads available to run validation.
     ///
     /// This is the server's real capacity, and it is worth being explicit about
@@ -79,6 +108,14 @@ impl Default for Config {
             max_message_bytes: 4 * 1024 * 1024,
             caller_header: "x-vastlint-caller".to_string(),
             worker_threads: None,
+            // Enough to keep the validation pool busy without letting one
+            // stream reserve more capacity than the server has. Larger buys
+            // nothing: the concurrency limiter is what decides how much work
+            // actually runs, and a deeper buffer only adds queueing time ahead
+            // of a decision that has already been made.
+            stream_buffer: 32,
+            stream_window_bytes: None,
+            connection_window_bytes: None,
             blocking_threads: default_blocking_threads(),
         }
     }
@@ -174,6 +211,15 @@ impl Config {
             max_message_bytes: env_parse("VASTLINT_MAX_MESSAGE_BYTES", defaults.max_message_bytes)?,
             caller_header: std::env::var("VASTLINT_CALLER_HEADER")
                 .unwrap_or(defaults.caller_header),
+            stream_buffer: env_parse("VASTLINT_STREAM_BUFFER", defaults.stream_buffer)?,
+            stream_window_bytes: match std::env::var("VASTLINT_STREAM_WINDOW_BYTES") {
+                Ok(raw) => Some(parse("VASTLINT_STREAM_WINDOW_BYTES", &raw)?),
+                Err(_) => defaults.stream_window_bytes,
+            },
+            connection_window_bytes: match std::env::var("VASTLINT_CONNECTION_WINDOW_BYTES") {
+                Ok(raw) => Some(parse("VASTLINT_CONNECTION_WINDOW_BYTES", &raw)?),
+                Err(_) => defaults.connection_window_bytes,
+            },
             worker_threads: match std::env::var("VASTLINT_WORKER_THREADS") {
                 Ok(raw) => Some(parse("VASTLINT_WORKER_THREADS", &raw)?),
                 Err(_) => defaults.worker_threads,
@@ -215,6 +261,28 @@ impl Config {
             return Err(ConfigError::Invalid {
                 name: "VASTLINT_MAX_MESSAGE_BYTES",
                 reason: "must be at least 1",
+            });
+        }
+
+        // HTTP/2 requires the connection window to be at least as large as a
+        // stream window; a smaller one would throttle every stream to a size
+        // the operator did not ask for.
+        if let (Some(stream), Some(connection)) =
+            (self.stream_window_bytes, self.connection_window_bytes)
+        {
+            if connection < stream {
+                return Err(ConfigError::Invalid {
+                    name: "VASTLINT_CONNECTION_WINDOW_BYTES",
+                    reason: "must be at least VASTLINT_STREAM_WINDOW_BYTES, or every stream is \
+                             throttled below its own window",
+                });
+            }
+        }
+
+        if self.stream_buffer == 0 {
+            return Err(ConfigError::Invalid {
+                name: "VASTLINT_STREAM_BUFFER",
+                reason: "must be at least 1, or a stream can never admit a message",
             });
         }
 

--- a/crates/vastlint-grpc/src/config.rs
+++ b/crates/vastlint-grpc/src/config.rs
@@ -52,6 +52,8 @@ pub struct Config {
     /// buffer would accept the whole firehose into memory and call it
     /// throughput.
     pub stream_buffer: usize,
+    /// Results stream settings.
+    pub events: EventConfig,
     /// Threads available to run validation.
     ///
     /// This is the server's real capacity, and it is worth being explicit about
@@ -83,6 +85,29 @@ pub struct LimitConfig {
     pub backoff_ratio: f64,
 }
 
+/// Validation event stream settings.
+///
+/// Off by default. A results topic nobody consumes is pure cost, and turning it
+/// on should be a decision somebody made rather than something that happens
+/// because a default said so.
+#[derive(Debug, Clone, Default)]
+pub struct EventConfig {
+    pub enabled: bool,
+    /// Kafka bootstrap servers. Empty means events are encoded and discarded,
+    /// which is useful for measuring the cost of the encoding without a broker.
+    pub brokers: String,
+    pub topic: String,
+    /// Schema ID as registered in the schema registry.
+    ///
+    /// Configured rather than fetched. Registering the schema and reading back
+    /// its ID is an operational step, and a server that self-registers on
+    /// startup can quietly create a new schema version during a rollback. See
+    /// the README for the registration command.
+    pub schema_id: u32,
+    /// Events buffered before new ones are dropped.
+    pub buffer: usize,
+}
+
 /// Per-caller token bucket settings.
 ///
 /// Both fields default to zero, which disables the limiter. A rate limit with a
@@ -107,6 +132,13 @@ impl Default for Config {
             // 40 MB wrapper chain is an attack, not a creative.
             max_message_bytes: 4 * 1024 * 1024,
             caller_header: "x-vastlint-caller".to_string(),
+            events: EventConfig {
+                enabled: false,
+                brokers: String::new(),
+                topic: "vastlint.validation.v1".to_string(),
+                schema_id: 0,
+                buffer: 1024,
+            },
             worker_threads: None,
             // Enough to keep the validation pool busy without letting one
             // stream reserve more capacity than the server has. Larger buys
@@ -211,6 +243,13 @@ impl Config {
             max_message_bytes: env_parse("VASTLINT_MAX_MESSAGE_BYTES", defaults.max_message_bytes)?,
             caller_header: std::env::var("VASTLINT_CALLER_HEADER")
                 .unwrap_or(defaults.caller_header),
+            events: EventConfig {
+                enabled: env_flag("VASTLINT_EVENTS_ENABLED", defaults.events.enabled)?,
+                brokers: std::env::var("VASTLINT_KAFKA_BROKERS").unwrap_or(defaults.events.brokers),
+                topic: std::env::var("VASTLINT_KAFKA_TOPIC").unwrap_or(defaults.events.topic),
+                schema_id: env_parse("VASTLINT_SCHEMA_ID", defaults.events.schema_id)?,
+                buffer: env_parse("VASTLINT_EVENTS_BUFFER", defaults.events.buffer)?,
+            },
             stream_buffer: env_parse("VASTLINT_STREAM_BUFFER", defaults.stream_buffer)?,
             stream_window_bytes: match std::env::var("VASTLINT_STREAM_WINDOW_BYTES") {
                 Ok(raw) => Some(parse("VASTLINT_STREAM_WINDOW_BYTES", &raw)?),
@@ -277,6 +316,25 @@ impl Config {
                              throttled below its own window",
                 });
             }
+        }
+
+        // A schema ID of zero is not a valid Confluent registry ID, and
+        // publishing under it would produce records no consumer can resolve.
+        // Better to refuse at startup than to fill a topic with undecodable
+        // bytes.
+        if self.events.enabled && self.events.schema_id == 0 {
+            return Err(ConfigError::Invalid {
+                name: "VASTLINT_SCHEMA_ID",
+                reason: "must be set when events are enabled: records are framed with the \
+                         registry schema id, and 0 is not one",
+            });
+        }
+
+        if self.events.enabled && self.events.buffer == 0 {
+            return Err(ConfigError::Invalid {
+                name: "VASTLINT_EVENTS_BUFFER",
+                reason: "must be at least 1, or every event is dropped",
+            });
         }
 
         if self.stream_buffer == 0 {
@@ -419,6 +477,25 @@ mod tests {
             config.blocking_threads <= 256,
             "a CPU-bound pool should track cores, not tokio's blocking default"
         );
+    }
+
+    /// Framing every record with schema id 0 would fill a topic with bytes no
+    /// consumer can resolve, and the failure would surface days later in
+    /// somebody else's pipeline.
+    #[test]
+    fn enabling_events_without_a_schema_id_is_rejected() {
+        let mut config = Config::default();
+        config.events.enabled = true;
+        config.events.schema_id = 0;
+        assert!(config.validate().is_err());
+
+        config.events.schema_id = 42;
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn events_are_off_by_default() {
+        assert!(!Config::default().events.enabled);
     }
 
     #[test]

--- a/crates/vastlint-grpc/src/convert.rs
+++ b/crates/vastlint-grpc/src/convert.rs
@@ -1,0 +1,540 @@
+//! Mapping between `vastlint-core` types and the wire contract.
+//!
+//! Kept in one place, and kept dumb. The transport layer must not decide
+//! anything about validation; if a mapping here needs a judgement call, the
+//! judgement belongs in the core where the CLI gets it too.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use tonic::Status;
+use vastlint_core as core;
+
+use crate::proto;
+use crate::provenance::provenance;
+
+/// Server default for wrapper chain depth, matching the IAB VAST 4.x
+/// recommendation and `core::ValidationContext::default`.
+const DEFAULT_MAX_WRAPPER_DEPTH: u8 = 5;
+
+// ── Core to wire ─────────────────────────────────────────────────────────────
+
+pub fn severity(value: core::Severity) -> proto::Severity {
+    match value {
+        core::Severity::Error => proto::Severity::Error,
+        core::Severity::Warning => proto::Severity::Warning,
+        core::Severity::Info => proto::Severity::Info,
+    }
+}
+
+pub fn vast_version(value: core::VastVersion) -> proto::VastVersion {
+    match value {
+        core::VastVersion::V2_0 => proto::VastVersion::VastVersion20,
+        core::VastVersion::V3_0 => proto::VastVersion::VastVersion30,
+        core::VastVersion::V4_0 => proto::VastVersion::VastVersion40,
+        core::VastVersion::V4_1 => proto::VastVersion::VastVersion41,
+        core::VastVersion::V4_2 => proto::VastVersion::VastVersion42,
+        core::VastVersion::V4_3 => proto::VastVersion::VastVersion43,
+        core::VastVersion::V4_4 => proto::VastVersion::VastVersion44,
+    }
+}
+
+pub fn document_type(value: core::DocumentType) -> proto::DocumentType {
+    match value {
+        core::DocumentType::Vast => proto::DocumentType::Vast,
+        core::DocumentType::Vmap => proto::DocumentType::Vmap,
+        core::DocumentType::Daast => proto::DocumentType::Daast,
+    }
+}
+
+pub fn rule_source(value: core::RuleSource) -> proto::RuleSource {
+    match value {
+        core::RuleSource::VastSpec => proto::RuleSource::VastSpec,
+        core::RuleSource::VastXsd => proto::RuleSource::VastXsd,
+        core::RuleSource::Xml => proto::RuleSource::Xml,
+        core::RuleSource::Rfc3986 => proto::RuleSource::Rfc3986,
+        core::RuleSource::IanaMediaTypes => proto::RuleSource::IanaMediaTypes,
+        core::RuleSource::Iso4217 => proto::RuleSource::Iso4217,
+        core::RuleSource::AdId => proto::RuleSource::AdId,
+        core::RuleSource::Inferred => proto::RuleSource::Inferred,
+        core::RuleSource::SimidSpec => proto::RuleSource::SimidSpec,
+        core::RuleSource::VmapSpec => proto::RuleSource::VmapSpec,
+        core::RuleSource::DaastSpec => proto::RuleSource::DaastSpec,
+        core::RuleSource::DaastXsd => proto::RuleSource::DaastXsd,
+        core::RuleSource::IndustryBestPractice => proto::RuleSource::IndustryBestPractice,
+        core::RuleSource::CtvAdPortfolio => proto::RuleSource::CtvAdPortfolio,
+    }
+}
+
+pub fn issue(value: &core::Issue) -> proto::Issue {
+    proto::Issue {
+        rule_id: value.id.to_string(),
+        severity: severity(value.severity) as i32,
+        message: value.message.to_string(),
+        // The contract says empty means document-level, so `None` flattens to
+        // the empty string rather than becoming an optional field. A path is
+        // never legitimately empty, so the two are not ambiguous.
+        path: value.path.clone().unwrap_or_default(),
+        spec_ref: value.spec_ref.to_string(),
+        // Position stays optional: 0 is not a valid 1-based line, and a caller
+        // that sees `0` where it expected "unset" will render "line 0".
+        line: value.line,
+        column: value.col,
+    }
+}
+
+pub fn summary(value: &core::Summary) -> proto::Summary {
+    proto::Summary {
+        // usize to u32. A document producing four billion findings is not a
+        // document, and saturating beats wrapping to a small number that would
+        // read as a nearly clean result.
+        errors: value.errors.try_into().unwrap_or(u32::MAX),
+        warnings: value.warnings.try_into().unwrap_or(u32::MAX),
+        infos: value.infos.try_into().unwrap_or(u32::MAX),
+    }
+}
+
+/// Maps version detection, including the declared-versus-inferred disagreement
+/// that a scalar version field would silently discard.
+///
+/// `forced` is the caller's override, which wins for `effective` because it is
+/// what validation actually ran against, while `declared` and `inferred` keep
+/// reporting what the document itself said.
+pub fn detected_version(
+    value: &core::DetectedVersion,
+    forced: Option<core::VastVersion>,
+) -> proto::DetectedVersion {
+    use core::DetectedVersion as D;
+
+    let (source, declared, inferred, consistent) = match value {
+        D::Declared(v) => (
+            proto::DetectionSource::Declared,
+            Some(*v),
+            None,
+            // Only meaningful when both are present. False here means "not
+            // applicable", which the contract states.
+            false,
+        ),
+        D::Inferred(v) => (proto::DetectionSource::Inferred, None, Some(*v), false),
+        D::DeclaredAndInferred {
+            declared,
+            inferred,
+            consistent,
+        } => (
+            proto::DetectionSource::DeclaredAndInferred,
+            Some(*declared),
+            Some(*inferred),
+            *consistent,
+        ),
+        D::Unknown => (proto::DetectionSource::Unknown, None, None, false),
+    };
+
+    let effective = forced
+        .or_else(|| value.best().copied())
+        .map(vast_version)
+        .unwrap_or(proto::VastVersion::Unspecified);
+
+    proto::DetectedVersion {
+        source: source as i32,
+        declared: declared
+            .map(vast_version)
+            .unwrap_or(proto::VastVersion::Unspecified) as i32,
+        inferred: inferred
+            .map(vast_version)
+            .unwrap_or(proto::VastVersion::Unspecified) as i32,
+        consistent,
+        effective: effective as i32,
+    }
+}
+
+pub fn verdict(
+    result: &core::ValidationResult,
+    forced: Option<core::VastVersion>,
+) -> proto::Verdict {
+    proto::Verdict {
+        valid: result.summary.is_valid(),
+        document_type: document_type(result.document_type) as i32,
+        detected_version: Some(detected_version(&result.version, forced)),
+        issues: result.issues.iter().map(issue).collect(),
+        summary: Some(summary(&result.summary)),
+        provenance: Some(provenance()),
+    }
+}
+
+pub fn applied_fix(value: &core::AppliedFix) -> proto::AppliedFix {
+    proto::AppliedFix {
+        rule_id: value.rule_id.to_string(),
+        description: value.description.clone(),
+        path: value.path.clone(),
+    }
+}
+
+pub fn rule_meta(value: &core::RuleMeta) -> proto::RuleMeta {
+    proto::RuleMeta {
+        rule_id: value.id.to_string(),
+        default_severity: severity(value.default_severity) as i32,
+        description: value.description.to_string(),
+        source: rule_source(value.source) as i32,
+        revenue_impact: value.revenue_impact(),
+        // The core catalog has no deprecation concept yet. The contract carries
+        // the fields because the ID stability policy promises them, and a
+        // consumer reading `deprecated: false` on every rule is correct today.
+        deprecated: false,
+        superseded_by: String::new(),
+    }
+}
+
+// ── Wire to core ─────────────────────────────────────────────────────────────
+
+/// Every rule ID in the catalog, mapped to its `'static` spelling.
+///
+/// `core::ValidationContext::rule_overrides` is keyed by `&'static str`, so an
+/// override arriving over the wire has to be resolved back to the catalog's own
+/// string rather than leaked from the request.
+fn catalog_ids() -> &'static HashMap<&'static str, &'static str> {
+    static IDS: OnceLock<HashMap<&'static str, &'static str>> = OnceLock::new();
+    IDS.get_or_init(|| {
+        core::all_rules()
+            .iter()
+            .map(|rule| (rule.id, rule.id))
+            .collect()
+    })
+}
+
+fn rule_level(value: proto::RuleLevel) -> Option<core::RuleLevel> {
+    match value {
+        proto::RuleLevel::Error => Some(core::RuleLevel::Error),
+        proto::RuleLevel::Warning => Some(core::RuleLevel::Warning),
+        proto::RuleLevel::Info => Some(core::RuleLevel::Info),
+        proto::RuleLevel::Off => Some(core::RuleLevel::Off),
+        proto::RuleLevel::Unspecified => None,
+    }
+}
+
+/// Builds a core validation context from the request.
+///
+/// Rejects rather than silently repairs. An unknown rule ID, an unspecified
+/// override level, or a wrapper depth that cannot fit is a client bug, and the
+/// failure mode of quietly ignoring it is a caller who believes they disabled a
+/// rule that keeps firing.
+pub fn validation_context(
+    value: Option<proto::ValidationContext>,
+) -> Result<(core::ValidationContext, Option<core::VastVersion>), Status> {
+    let Some(value) = value else {
+        return Ok((core::ValidationContext::default(), None));
+    };
+
+    let wrapper_depth: u8 = value.wrapper_depth.try_into().map_err(|_| {
+        Status::invalid_argument(format!(
+            "wrapper_depth {} exceeds the maximum of {}",
+            value.wrapper_depth,
+            u8::MAX
+        ))
+    })?;
+
+    // 0 means "server default", not "no wrappers permitted". A
+    // default-constructed message must not change validation behaviour, which
+    // is the whole reason proto3 scalars have no presence.
+    let max_wrapper_depth = if value.max_wrapper_depth == 0 {
+        DEFAULT_MAX_WRAPPER_DEPTH
+    } else {
+        value.max_wrapper_depth.try_into().map_err(|_| {
+            Status::invalid_argument(format!(
+                "max_wrapper_depth {} exceeds the maximum of {}",
+                value.max_wrapper_depth,
+                u8::MAX
+            ))
+        })?
+    };
+
+    let forced_version = match value.forced_version() {
+        proto::VastVersion::Unspecified => None,
+        proto::VastVersion::VastVersion20 => Some(core::VastVersion::V2_0),
+        proto::VastVersion::VastVersion30 => Some(core::VastVersion::V3_0),
+        proto::VastVersion::VastVersion40 => Some(core::VastVersion::V4_0),
+        proto::VastVersion::VastVersion41 => Some(core::VastVersion::V4_1),
+        proto::VastVersion::VastVersion42 => Some(core::VastVersion::V4_2),
+        proto::VastVersion::VastVersion43 => Some(core::VastVersion::V4_3),
+        proto::VastVersion::VastVersion44 => Some(core::VastVersion::V4_4),
+    };
+
+    let rule_overrides = rule_overrides(&value.rule_overrides)?;
+
+    Ok((
+        core::ValidationContext {
+            wrapper_depth,
+            max_wrapper_depth,
+            rule_overrides,
+            forced_version,
+        },
+        forced_version,
+    ))
+}
+
+fn rule_overrides(
+    raw: &HashMap<String, i32>,
+) -> Result<Option<HashMap<&'static str, core::RuleLevel>>, Status> {
+    if raw.is_empty() {
+        // None means "all recommended defaults", which is not the same as an
+        // empty override map only because the core treats them identically
+        // today. Sending None keeps that explicit.
+        return Ok(None);
+    }
+
+    let ids = catalog_ids();
+    let mut unknown: Vec<&str> = Vec::new();
+    let mut resolved = HashMap::with_capacity(raw.len());
+
+    for (id, level) in raw {
+        let Some(canonical) = ids.get(id.as_str()) else {
+            unknown.push(id);
+            continue;
+        };
+
+        let level = proto::RuleLevel::try_from(*level).map_err(|_| {
+            Status::invalid_argument(format!("rule_overrides[{id}] has an unrecognised level"))
+        })?;
+
+        let Some(level) = rule_level(level) else {
+            return Err(Status::invalid_argument(format!(
+                "rule_overrides[{id}] is RULE_LEVEL_UNSPECIFIED; use RULE_LEVEL_OFF to silence a rule"
+            )));
+        };
+
+        resolved.insert(*canonical, level);
+    }
+
+    if !unknown.is_empty() {
+        // Sorted so the message is stable across runs: HashMap iteration order
+        // is not, and an error message that reorders itself is hard to test and
+        // harder to grep for in logs.
+        unknown.sort_unstable();
+        return Err(Status::invalid_argument(format!(
+            "unknown rule IDs in rule_overrides: {}. Call ListRules for the catalog",
+            unknown.join(", ")
+        )));
+    }
+
+    Ok(Some(resolved))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context_with_overrides(pairs: &[(&str, proto::RuleLevel)]) -> proto::ValidationContext {
+        proto::ValidationContext {
+            rule_overrides: pairs
+                .iter()
+                .map(|(id, level)| ((*id).to_string(), *level as i32))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn a_real_rule_id() -> &'static str {
+        core::all_rules().first().expect("catalog is not empty").id
+    }
+
+    #[test]
+    fn absent_context_uses_core_defaults() {
+        let (context, forced) = validation_context(None).unwrap();
+        assert_eq!(context.max_wrapper_depth, DEFAULT_MAX_WRAPPER_DEPTH);
+        assert_eq!(context.wrapper_depth, 0);
+        assert!(context.rule_overrides.is_none());
+        assert!(forced.is_none());
+    }
+
+    /// The trap this guards: proto3 gives an unset uint32 the value 0, so a
+    /// caller sending an empty context would otherwise get "no wrappers
+    /// allowed" instead of the documented default.
+    #[test]
+    fn zero_max_wrapper_depth_means_server_default() {
+        let (context, _) = validation_context(Some(proto::ValidationContext::default())).unwrap();
+        assert_eq!(context.max_wrapper_depth, DEFAULT_MAX_WRAPPER_DEPTH);
+    }
+
+    #[test]
+    fn explicit_max_wrapper_depth_is_honoured() {
+        let (context, _) = validation_context(Some(proto::ValidationContext {
+            max_wrapper_depth: 2,
+            ..Default::default()
+        }))
+        .unwrap();
+        assert_eq!(context.max_wrapper_depth, 2);
+    }
+
+    #[test]
+    fn oversized_depths_are_rejected_not_truncated() {
+        let err = validation_context(Some(proto::ValidationContext {
+            wrapper_depth: 300,
+            ..Default::default()
+        }))
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+        let err = validation_context(Some(proto::ValidationContext {
+            max_wrapper_depth: 100_000,
+            ..Default::default()
+        }))
+        .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn known_rule_overrides_resolve_to_catalog_ids() {
+        let id = a_real_rule_id();
+        let (context, _) =
+            validation_context(Some(context_with_overrides(&[(id, proto::RuleLevel::Off)])))
+                .unwrap();
+
+        let overrides = context.rule_overrides.expect("overrides present");
+        assert_eq!(overrides.get(id), Some(&core::RuleLevel::Off));
+    }
+
+    /// A typo in a rule ID that silently disabled nothing is indistinguishable
+    /// from a rule that never fires, so it has to be an error.
+    #[test]
+    fn unknown_rule_ids_are_rejected() {
+        let err = validation_context(Some(context_with_overrides(&[(
+            "VAST-9.9-not-a-rule",
+            proto::RuleLevel::Off,
+        )])))
+        .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("VAST-9.9-not-a-rule"));
+        assert!(err.message().contains("ListRules"));
+    }
+
+    #[test]
+    fn unknown_rule_ids_are_reported_together_and_sorted() {
+        let err = validation_context(Some(context_with_overrides(&[
+            ("zzz-not-a-rule", proto::RuleLevel::Off),
+            ("aaa-not-a-rule", proto::RuleLevel::Off),
+        ])))
+        .unwrap_err();
+
+        let message = err.message();
+        let first = message.find("aaa-not-a-rule").expect("first id present");
+        let second = message.find("zzz-not-a-rule").expect("second id present");
+        assert!(first < second, "ids should be sorted: {message}");
+    }
+
+    #[test]
+    fn unspecified_override_level_is_rejected() {
+        let err = validation_context(Some(context_with_overrides(&[(
+            a_real_rule_id(),
+            proto::RuleLevel::Unspecified,
+        )])))
+        .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("RULE_LEVEL_OFF"));
+    }
+
+    #[test]
+    fn empty_overrides_mean_defaults_not_an_empty_map() {
+        let (context, _) = validation_context(Some(proto::ValidationContext::default())).unwrap();
+        assert!(context.rule_overrides.is_none());
+    }
+
+    #[test]
+    fn forced_version_round_trips() {
+        let (context, forced) = validation_context(Some(proto::ValidationContext {
+            forced_version: proto::VastVersion::VastVersion43 as i32,
+            ..Default::default()
+        }))
+        .unwrap();
+
+        assert_eq!(context.forced_version, Some(core::VastVersion::V4_3));
+        assert_eq!(forced, Some(core::VastVersion::V4_3));
+    }
+
+    /// Every core version must have a wire spelling. A new VAST version added
+    /// to the core without a proto value would otherwise be a compile error
+    /// here, which is the intent.
+    #[test]
+    fn every_version_maps_to_a_specified_value() {
+        for version in [
+            core::VastVersion::V2_0,
+            core::VastVersion::V3_0,
+            core::VastVersion::V4_0,
+            core::VastVersion::V4_1,
+            core::VastVersion::V4_2,
+            core::VastVersion::V4_3,
+            core::VastVersion::V4_4,
+        ] {
+            assert_ne!(vast_version(version), proto::VastVersion::Unspecified);
+        }
+    }
+
+    #[test]
+    fn every_rule_in_the_catalog_maps_to_a_specified_source() {
+        for rule in core::all_rules() {
+            assert_ne!(
+                rule_source(rule.source),
+                proto::RuleSource::Unspecified,
+                "rule {} has an unmapped source",
+                rule.id
+            );
+        }
+    }
+
+    #[test]
+    fn declared_and_inferred_disagreement_survives_the_mapping() {
+        let detected = core::DetectedVersion::DeclaredAndInferred {
+            declared: core::VastVersion::V4_1,
+            inferred: core::VastVersion::V3_0,
+            consistent: false,
+        };
+
+        let wire = detected_version(&detected, None);
+
+        assert_eq!(
+            wire.source,
+            proto::DetectionSource::DeclaredAndInferred as i32
+        );
+        assert_eq!(wire.declared, proto::VastVersion::VastVersion41 as i32);
+        assert_eq!(wire.inferred, proto::VastVersion::VastVersion30 as i32);
+        assert!(!wire.consistent);
+        // Declared wins for the effective version, matching core::best.
+        assert_eq!(wire.effective, proto::VastVersion::VastVersion41 as i32);
+    }
+
+    #[test]
+    fn forced_version_overrides_effective_but_not_what_the_document_said() {
+        let detected = core::DetectedVersion::Declared(core::VastVersion::V2_0);
+        let wire = detected_version(&detected, Some(core::VastVersion::V4_3));
+
+        assert_eq!(wire.declared, proto::VastVersion::VastVersion20 as i32);
+        assert_eq!(wire.effective, proto::VastVersion::VastVersion43 as i32);
+    }
+
+    #[test]
+    fn unknown_detection_reports_no_versions() {
+        let wire = detected_version(&core::DetectedVersion::Unknown, None);
+        assert_eq!(wire.source, proto::DetectionSource::Unknown as i32);
+        assert_eq!(wire.declared, proto::VastVersion::Unspecified as i32);
+        assert_eq!(wire.inferred, proto::VastVersion::Unspecified as i32);
+        assert_eq!(wire.effective, proto::VastVersion::Unspecified as i32);
+    }
+
+    #[test]
+    fn document_level_issues_have_no_position() {
+        let core_issue = core::Issue {
+            id: "TEST-rule",
+            severity: core::Severity::Error,
+            message: "test",
+            path: None,
+            spec_ref: "test",
+            line: None,
+            col: None,
+        };
+
+        let wire = issue(&core_issue);
+        assert_eq!(wire.path, "");
+        assert_eq!(wire.line, None);
+        assert_eq!(wire.column, None);
+    }
+}

--- a/crates/vastlint-grpc/src/deadline.rs
+++ b/crates/vastlint-grpc/src/deadline.rs
@@ -1,0 +1,120 @@
+//! Client deadline propagation.
+//!
+//! gRPC clients express a deadline as a `grpc-timeout` header holding a
+//! duration relative to when the request was sent. tonic does not act on it for
+//! you, so a server that ignores it will happily spend a second producing a
+//! result for a caller that gave up after ten milliseconds. In a bid path that
+//! is not merely wasteful: the work competes for the same capacity as requests
+//! that can still be answered in time.
+//!
+//! Wire format is a decimal value followed by a one-character unit, per the
+//! gRPC over HTTP/2 specification:
+//!
+//! ```text
+//! H  hours    M  minutes    S  seconds
+//! m  millis   u  micros     n  nanos
+//! ```
+
+use std::time::Duration;
+
+use tonic::metadata::MetadataMap;
+
+/// The header gRPC clients use to express a deadline.
+const TIMEOUT_HEADER: &str = "grpc-timeout";
+
+/// Reads the caller's remaining time budget, if it declared one.
+///
+/// Returns `None` when the header is absent, which means the caller accepted
+/// whatever the server takes. A malformed header is also `None` rather than an
+/// error: refusing a request over an unparseable timeout would be a worse
+/// failure than serving it, and the specification's own guidance is to treat
+/// the value as advisory.
+pub fn remaining(metadata: &MetadataMap) -> Option<Duration> {
+    let raw = metadata.get(TIMEOUT_HEADER)?.to_str().ok()?;
+    parse(raw)
+}
+
+/// Parses a `grpc-timeout` value into a duration.
+fn parse(raw: &str) -> Option<Duration> {
+    let (value, unit) = raw.split_at(raw.len().checked_sub(1)?);
+    let value: u64 = value.parse().ok()?;
+
+    // Saturating rather than wrapping: the spec caps the value at 8 digits, but
+    // a non-conforming client sending a large hour count should get "a very
+    // long time" rather than a wrapped-around short one.
+    match unit {
+        "H" => Some(Duration::from_secs(value.saturating_mul(3600))),
+        "M" => Some(Duration::from_secs(value.saturating_mul(60))),
+        "S" => Some(Duration::from_secs(value)),
+        "m" => Some(Duration::from_millis(value)),
+        "u" => Some(Duration::from_micros(value)),
+        "n" => Some(Duration::from_nanos(value)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_every_unit() {
+        assert_eq!(parse("3H"), Some(Duration::from_secs(10_800)));
+        assert_eq!(parse("2M"), Some(Duration::from_secs(120)));
+        assert_eq!(parse("30S"), Some(Duration::from_secs(30)));
+        assert_eq!(parse("250m"), Some(Duration::from_millis(250)));
+        assert_eq!(parse("500u"), Some(Duration::from_micros(500)));
+        assert_eq!(parse("100n"), Some(Duration::from_nanos(100)));
+    }
+
+    /// Case matters: `M` is minutes and `m` is milliseconds. Getting this
+    /// backwards turns a 100ms budget into a 100 minute one.
+    #[test]
+    fn units_are_case_sensitive() {
+        assert_eq!(parse("100M"), Some(Duration::from_secs(6_000)));
+        assert_eq!(parse("100m"), Some(Duration::from_millis(100)));
+    }
+
+    #[test]
+    fn rejects_malformed_values() {
+        assert_eq!(parse(""), None);
+        assert_eq!(parse("m"), None);
+        assert_eq!(parse("100"), None);
+        assert_eq!(parse("100x"), None);
+        assert_eq!(parse("-5S"), None);
+        assert_eq!(parse("1.5S"), None);
+        assert_eq!(parse("abcS"), None);
+    }
+
+    #[test]
+    fn zero_is_a_valid_deadline_meaning_no_time_left() {
+        assert_eq!(parse("0m"), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn absent_header_means_no_deadline() {
+        assert_eq!(remaining(&MetadataMap::new()), None);
+    }
+
+    #[test]
+    fn reads_the_header_when_present() {
+        let mut metadata = MetadataMap::new();
+        metadata.insert(TIMEOUT_HEADER, "40m".parse().unwrap());
+        assert_eq!(remaining(&metadata), Some(Duration::from_millis(40)));
+    }
+
+    #[test]
+    fn malformed_header_is_treated_as_no_deadline() {
+        let mut metadata = MetadataMap::new();
+        metadata.insert(TIMEOUT_HEADER, "not-a-timeout".parse().unwrap());
+        assert_eq!(remaining(&metadata), None);
+    }
+
+    #[test]
+    fn large_hour_counts_saturate_rather_than_wrap() {
+        assert_eq!(
+            parse(&format!("{}H", u64::MAX)),
+            Some(Duration::from_secs(u64::MAX))
+        );
+    }
+}

--- a/crates/vastlint-grpc/src/events.rs
+++ b/crates/vastlint-grpc/src/events.rs
@@ -1,0 +1,524 @@
+//! Validation events, Avro-encoded, for a Kafka results stream.
+//!
+//! The motivating case is an SSP that wants a stream of creative rejections
+//! rather than a request-response call: it does not have a document to ask
+//! about, it wants to know which ones are failing.
+//!
+//! ## Why Avro here and protobuf on the wire
+//!
+//! Not inconsistency. They are solving different problems, and the difference
+//! is the interesting part.
+//!
+//! The gRPC contract is a *call* contract, negotiated between two parties who
+//! are both present. Both sides can be told to upgrade, and `buf breaking`
+//! enforces that at commit time in the repository that owns the contract.
+//!
+//! A topic is a *storage* contract with readers who are not present. Records
+//! written today are read months later by consumers nobody controls, running
+//! schema versions nobody chose. Avro's writer-schema-plus-reader-schema
+//! resolution is built for exactly that: every record carries the identity of
+//! the schema it was written under, and readers resolve against it rather than
+//! assuming.
+//!
+//! ## The compatibility guarantee, and where it is enforced
+//!
+//! The subject is registered BACKWARD, so a reader on the current schema can
+//! read every record ever written. A registry enforces that at registration
+//! time, once, when someone remembers to register. The tests at the bottom of
+//! this file enforce it on every commit, which is the same argument as
+//! `buf breaking` versus a code review convention.
+//!
+//! ## Emission never blocks validation
+//!
+//! Events go onto a bounded channel and are dropped when it is full, with a
+//! counter. Telemetry that adds latency to a bid path is worse than no
+//! telemetry, and a full queue must shed events rather than requests. This is
+//! the same policy as the concurrency limiter, applied to a place where the
+//! stakes are lower and the temptation to buffer is higher.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use apache_avro::types::{Record, Value};
+use apache_avro::Schema;
+use vastlint_core as core;
+
+/// The schema this build writes with.
+///
+/// Compiled in rather than fetched, so the binary cannot write records under a
+/// schema it does not itself contain.
+pub const SCHEMA_JSON: &str =
+    include_str!("../../../schemas/openadtech/vastlint/v1/validation_event.avsc");
+
+/// Confluent wire format: one magic byte, then a four-byte big-endian schema
+/// ID, then the Avro binary datum.
+///
+/// Framing rather than a bare datum because that is what every Kafka consumer
+/// in this ecosystem expects, and because the schema ID is what lets a reader
+/// resolve a record written under a version it has never seen.
+const MAGIC_BYTE: u8 = 0;
+
+/// Parsed once. Parsing per event would put JSON parsing on the hot path to
+/// serialise a struct that is already in memory.
+pub fn schema() -> &'static Schema {
+    static SCHEMA: std::sync::OnceLock<Schema> = std::sync::OnceLock::new();
+    SCHEMA.get_or_init(|| Schema::parse_str(SCHEMA_JSON).expect("the bundled schema parses"))
+}
+
+/// Somewhere for events to go.
+///
+/// A trait so the Kafka client stays behind a feature flag. A build without it
+/// still produces, encodes, and drops events through the same path, so the
+/// encoding is exercised whether or not a broker exists.
+pub trait Sink: Send + Sync {
+    /// Called with one framed, encoded event. Must not block.
+    fn publish(&self, key: &str, payload: &[u8]);
+}
+
+/// Discards everything, counting as it goes.
+///
+/// The default. A server with no broker configured should not fail to start,
+/// and should not pretend it is publishing.
+#[derive(Debug, Default)]
+pub struct NullSink {
+    published: AtomicU64,
+}
+
+impl NullSink {
+    pub fn published(&self) -> u64 {
+        self.published.load(Ordering::Relaxed)
+    }
+}
+
+impl Sink for NullSink {
+    fn publish(&self, _key: &str, _payload: &[u8]) {
+        self.published.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// One completed validation, before encoding.
+#[derive(Debug, Clone)]
+pub struct ValidationEvent {
+    pub event_id: String,
+    pub occurred_at_ms: i64,
+    pub document_type: &'static str,
+    pub effective_version: Option<String>,
+    pub valid: bool,
+    pub errors: i32,
+    pub warnings: i32,
+    pub infos: i32,
+    pub findings: Vec<Finding>,
+    pub catalog_version: String,
+    pub catalog_digest: String,
+    pub engine_version: String,
+    pub caller: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Finding {
+    pub rule_id: String,
+    pub severity: &'static str,
+    pub message: String,
+    pub path: Option<String>,
+    pub spec_ref: Option<String>,
+}
+
+impl ValidationEvent {
+    /// Builds an event from a validation result.
+    ///
+    /// `event_id` is supplied rather than generated here so the caller can use
+    /// a request id it already has, which makes an event traceable back to the
+    /// call that produced it.
+    pub fn from_result(
+        event_id: String,
+        result: &core::ValidationResult,
+        effective_version: Option<String>,
+        caller: Option<String>,
+    ) -> Self {
+        Self {
+            event_id,
+            occurred_at_ms: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|since| since.as_millis() as i64)
+                .unwrap_or(0),
+            document_type: result.document_type.as_str(),
+            effective_version,
+            valid: result.summary.is_valid(),
+            errors: result.summary.errors.try_into().unwrap_or(i32::MAX),
+            warnings: result.summary.warnings.try_into().unwrap_or(i32::MAX),
+            infos: result.summary.infos.try_into().unwrap_or(i32::MAX),
+            findings: result
+                .issues
+                .iter()
+                .map(|issue| Finding {
+                    rule_id: issue.id.to_string(),
+                    severity: severity_symbol(issue.severity),
+                    message: issue.message.to_string(),
+                    path: issue.path.clone(),
+                    spec_ref: Some(issue.spec_ref.to_string()),
+                })
+                .collect(),
+            catalog_version: core::VERSION.to_string(),
+            catalog_digest: crate::provenance::catalog_digest().to_string(),
+            engine_version: core::VERSION.to_string(),
+            caller,
+        }
+    }
+
+    /// Encodes to the Confluent wire format.
+    pub fn encode(&self, schema_id: u32) -> Result<Vec<u8>, apache_avro::Error> {
+        let schema = schema();
+        let mut record = Record::new(schema).expect("the bundled schema is a record");
+
+        record.put("event_id", Value::String(self.event_id.clone()));
+        record.put("occurred_at_ms", Value::Long(self.occurred_at_ms));
+        record.put(
+            "document_type",
+            Value::Enum(
+                document_type_index(self.document_type),
+                self.document_type.to_string(),
+            ),
+        );
+        record.put(
+            "effective_version",
+            optional_string(self.effective_version.clone()),
+        );
+        record.put("valid", Value::Boolean(self.valid));
+        record.put("errors", Value::Int(self.errors));
+        record.put("warnings", Value::Int(self.warnings));
+        record.put("infos", Value::Int(self.infos));
+        record.put(
+            "findings",
+            Value::Array(self.findings.iter().map(finding_value).collect()),
+        );
+        record.put(
+            "catalog_version",
+            Value::String(self.catalog_version.clone()),
+        );
+        record.put("catalog_digest", Value::String(self.catalog_digest.clone()));
+        record.put("engine_version", Value::String(self.engine_version.clone()));
+        record.put("caller", optional_string(self.caller.clone()));
+
+        let datum = apache_avro::to_avro_datum(schema, record)?;
+
+        let mut framed = Vec::with_capacity(5 + datum.len());
+        framed.push(MAGIC_BYTE);
+        framed.extend_from_slice(&schema_id.to_be_bytes());
+        framed.extend_from_slice(&datum);
+
+        Ok(framed)
+    }
+}
+
+fn optional_string(value: Option<String>) -> Value {
+    match value {
+        // Union branch indices are positional: 0 is null, 1 is string, because
+        // that is the order in the schema. Getting this backwards produces a
+        // record that encodes without error and decodes as the wrong branch.
+        Some(value) => Value::Union(1, Box::new(Value::String(value))),
+        None => Value::Union(0, Box::new(Value::Null)),
+    }
+}
+
+fn document_type_index(name: &str) -> u32 {
+    match name {
+        "VAST" => 0,
+        "VMAP" => 1,
+        "DAAST" => 2,
+        _ => 3,
+    }
+}
+
+/// The Avro enum spells severities in upper case; the core spells them in
+/// lower. Mapped here rather than changing either, because both spellings are
+/// already load-bearing in their own surfaces.
+fn severity_symbol(severity: core::Severity) -> &'static str {
+    match severity {
+        core::Severity::Error => "ERROR",
+        core::Severity::Warning => "WARNING",
+        core::Severity::Info => "INFO",
+    }
+}
+
+fn severity_index(name: &str) -> u32 {
+    match name {
+        "ERROR" => 0,
+        "WARNING" => 1,
+        "INFO" => 2,
+        _ => 3,
+    }
+}
+
+fn finding_value(finding: &Finding) -> Value {
+    Value::Record(vec![
+        (
+            "rule_id".to_string(),
+            Value::String(finding.rule_id.clone()),
+        ),
+        (
+            "severity".to_string(),
+            Value::Enum(
+                severity_index(finding.severity),
+                finding.severity.to_string(),
+            ),
+        ),
+        (
+            "message".to_string(),
+            Value::String(finding.message.clone()),
+        ),
+        ("path".to_string(), optional_string(finding.path.clone())),
+        (
+            "spec_ref".to_string(),
+            optional_string(finding.spec_ref.clone()),
+        ),
+    ])
+}
+
+/// Publishes events without ever blocking the caller.
+#[derive(Debug)]
+pub struct Publisher {
+    sender: tokio::sync::mpsc::Sender<(String, Vec<u8>)>,
+    dropped: Arc<AtomicU64>,
+}
+
+impl Publisher {
+    /// Spawns the background task that drains events into `sink`.
+    pub fn spawn(sink: Arc<dyn Sink>, capacity: usize, schema_id: u32) -> Self {
+        let (sender, mut receiver) =
+            tokio::sync::mpsc::channel::<(String, Vec<u8>)>(capacity.max(1));
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        tokio::spawn(async move {
+            while let Some((key, payload)) = receiver.recv().await {
+                sink.publish(&key, &payload);
+            }
+        });
+
+        let _ = schema_id;
+        Self { sender, dropped }
+    }
+
+    /// Events discarded because the queue was full.
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Queues an event, or drops it.
+    ///
+    /// `try_send` rather than `send`, deliberately. Awaiting here would make a
+    /// slow broker into validation latency, which is the failure this whole
+    /// server is built to avoid. Dropping a telemetry event to keep a bid-path
+    /// response fast is the correct trade, and the counter means the loss is
+    /// visible rather than silent.
+    pub fn publish(&self, event: &ValidationEvent, schema_id: u32) {
+        let payload = match event.encode(schema_id) {
+            Ok(payload) => payload,
+            Err(_) => {
+                // An encoding failure is a bug in this file, not a runtime
+                // condition, and it must not fail the validation that produced
+                // it. Counted with the drops so it cannot hide.
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        };
+
+        if self
+            .sender
+            .try_send((event.event_id.clone(), payload))
+            .is_err()
+        {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+            crate::metrics::record_event_dropped();
+        } else {
+            crate::metrics::record_event_published();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use apache_avro::from_avro_datum;
+
+    fn sample() -> ValidationEvent {
+        ValidationEvent {
+            event_id: "evt-1".to_string(),
+            occurred_at_ms: 1_754_700_000_000,
+            document_type: "VAST",
+            effective_version: Some("4.1".to_string()),
+            valid: false,
+            errors: 2,
+            warnings: 1,
+            infos: 0,
+            findings: vec![Finding {
+                rule_id: "VAST-2.0-inline-impression".to_string(),
+                severity: "ERROR",
+                message: "<InLine> is missing required <Impression>".to_string(),
+                path: Some("/VAST/Ad[0]/InLine".to_string()),
+                spec_ref: Some("IAB VAST 2.0 §2.3.4".to_string()),
+            }],
+            catalog_version: "0.11.7".to_string(),
+            catalog_digest: "sha256:abc".to_string(),
+            engine_version: "0.11.7".to_string(),
+            caller: None,
+        }
+    }
+
+    #[test]
+    fn the_bundled_schema_parses() {
+        let _ = schema();
+    }
+
+    #[test]
+    fn an_event_round_trips_through_its_own_schema() {
+        let encoded = sample().encode(42).expect("encodes");
+
+        assert_eq!(encoded[0], MAGIC_BYTE, "Confluent framing starts with 0");
+        assert_eq!(
+            u32::from_be_bytes(encoded[1..5].try_into().unwrap()),
+            42,
+            "the schema id is big-endian in bytes 1..5"
+        );
+
+        let mut body = &encoded[5..];
+        let decoded = from_avro_datum(schema(), &mut body, None).expect("decodes");
+
+        let Value::Record(fields) = decoded else {
+            panic!("expected a record");
+        };
+        let get = |name: &str| {
+            fields
+                .iter()
+                .find(|(field, _)| field == name)
+                .map(|(_, value)| value.clone())
+                .unwrap_or_else(|| panic!("missing field {name}"))
+        };
+
+        assert_eq!(get("event_id"), Value::String("evt-1".to_string()));
+        assert_eq!(get("valid"), Value::Boolean(false));
+        assert_eq!(get("errors"), Value::Int(2));
+    }
+
+    /// Union branch order is positional and silently wrong if inverted: a
+    /// record with the branches swapped still encodes, and decodes as the wrong
+    /// variant.
+    #[test]
+    fn optional_fields_encode_the_right_union_branch() {
+        let mut event = sample();
+        event.caller = None;
+        let encoded = event.encode(1).expect("encodes");
+        let mut body = &encoded[5..];
+        let decoded = from_avro_datum(schema(), &mut body, None).expect("decodes");
+
+        let Value::Record(fields) = decoded else {
+            panic!("expected a record")
+        };
+        let caller = fields
+            .iter()
+            .find(|(name, _)| name == "caller")
+            .map(|(_, value)| value.clone())
+            .expect("caller present");
+        assert_eq!(caller, Value::Union(0, Box::new(Value::Null)));
+
+        let mut event = sample();
+        event.caller = Some("ssp-1".to_string());
+        let encoded = event.encode(1).expect("encodes");
+        let mut body = &encoded[5..];
+        let decoded = from_avro_datum(schema(), &mut body, None).expect("decodes");
+
+        let Value::Record(fields) = decoded else {
+            panic!("expected a record")
+        };
+        let caller = fields
+            .iter()
+            .find(|(name, _)| name == "caller")
+            .map(|(_, value)| value.clone())
+            .expect("caller present");
+        assert_eq!(
+            caller,
+            Value::Union(1, Box::new(Value::String("ssp-1".to_string())))
+        );
+    }
+
+    #[tokio::test]
+    async fn publishing_never_blocks_and_drops_are_counted() {
+        // Capacity 1 and a sink that is never drained fast enough: the queue
+        // fills and the rest are dropped rather than awaited.
+        let sink: Arc<dyn Sink> = Arc::new(NullSink::default());
+        let publisher = Publisher::spawn(Arc::clone(&sink), 1, 1);
+
+        let event = sample();
+        for _ in 0..1_000 {
+            publisher.publish(&event, 1);
+        }
+
+        // The assertion is that this returned at all. Whether anything was
+        // dropped depends on how fast the drain task runs, so the useful
+        // invariant is that nothing hung and the counter is coherent.
+        assert!(publisher.dropped() <= 1_000);
+    }
+}
+
+/// Kafka producer sink.
+///
+/// Behind the `kafka` feature because `rdkafka` builds a vendored librdkafka,
+/// which is a multi-minute C build that every developer and CI job would
+/// otherwise pay for. Everything else in this module, including the encoding
+/// and the compatibility tests, works without it.
+#[cfg(feature = "kafka")]
+pub mod kafka {
+    use super::Sink;
+
+    /// Publishes to a Kafka topic, fire and forget.
+    pub struct KafkaSink {
+        producer: rdkafka::producer::FutureProducer,
+        topic: String,
+    }
+
+    impl KafkaSink {
+        pub fn new(brokers: &str, topic: &str) -> Result<Self, rdkafka::error::KafkaError> {
+            use rdkafka::config::ClientConfig;
+
+            let producer: rdkafka::producer::FutureProducer = ClientConfig::new()
+                .set("bootstrap.servers", brokers)
+                // Bounded, and small. The publisher already has a bounded queue
+                // in front of this; letting librdkafka buffer another hundred
+                // thousand messages would move the unboundedness one layer down
+                // rather than removing it.
+                .set("queue.buffering.max.messages", "10000")
+                // Batch briefly. Publishing every event individually would turn
+                // a results stream into a syscall per validation.
+                .set("linger.ms", "50")
+                // Do not block the producer thread when the queue is full. The
+                // send fails immediately and the event is dropped and counted,
+                // which is the same policy as everywhere else here.
+                .set("queue.buffering.max.ms", "50")
+                .create()?;
+
+            Ok(Self {
+                producer,
+                topic: topic.to_string(),
+            })
+        }
+    }
+
+    impl Sink for KafkaSink {
+        fn publish(&self, key: &str, payload: &[u8]) {
+            use rdkafka::producer::FutureRecord;
+
+            let record = FutureRecord::to(&self.topic).key(key).payload(payload);
+
+            // `send_result` queues without awaiting delivery. Awaiting here
+            // would put broker round trips on the drain task and make a slow
+            // broker into a growing queue upstream.
+            if self.producer.send_result(record).is_err() {
+                crate::metrics::record_event_dropped();
+            }
+
+            // Deliberately not flushing per message. Flushing is a shutdown
+            // concern, and doing it here would serialise the whole stream on
+            // broker acknowledgement.
+        }
+    }
+}

--- a/crates/vastlint-grpc/src/events.rs
+++ b/crates/vastlint-grpc/src/events.rs
@@ -460,65 +460,19 @@ mod tests {
     }
 }
 
-/// Kafka producer sink.
-///
-/// Behind the `kafka` feature because `rdkafka` builds a vendored librdkafka,
-/// which is a multi-minute C build that every developer and CI job would
-/// otherwise pay for. Everything else in this module, including the encoding
-/// and the compatibility tests, works without it.
-#[cfg(feature = "kafka")]
-pub mod kafka {
-    use super::Sink;
-
-    /// Publishes to a Kafka topic, fire and forget.
-    pub struct KafkaSink {
-        producer: rdkafka::producer::FutureProducer,
-        topic: String,
-    }
-
-    impl KafkaSink {
-        pub fn new(brokers: &str, topic: &str) -> Result<Self, rdkafka::error::KafkaError> {
-            use rdkafka::config::ClientConfig;
-
-            let producer: rdkafka::producer::FutureProducer = ClientConfig::new()
-                .set("bootstrap.servers", brokers)
-                // Bounded, and small. The publisher already has a bounded queue
-                // in front of this; letting librdkafka buffer another hundred
-                // thousand messages would move the unboundedness one layer down
-                // rather than removing it.
-                .set("queue.buffering.max.messages", "10000")
-                // Batch briefly. Publishing every event individually would turn
-                // a results stream into a syscall per validation.
-                .set("linger.ms", "50")
-                // Do not block the producer thread when the queue is full. The
-                // send fails immediately and the event is dropped and counted,
-                // which is the same policy as everywhere else here.
-                .set("queue.buffering.max.ms", "50")
-                .create()?;
-
-            Ok(Self {
-                producer,
-                topic: topic.to_string(),
-            })
-        }
-    }
-
-    impl Sink for KafkaSink {
-        fn publish(&self, key: &str, payload: &[u8]) {
-            use rdkafka::producer::FutureRecord;
-
-            let record = FutureRecord::to(&self.topic).key(key).payload(payload);
-
-            // `send_result` queues without awaiting delivery. Awaiting here
-            // would put broker round trips on the drain task and make a slow
-            // broker into a growing queue upstream.
-            if self.producer.send_result(record).is_err() {
-                crate::metrics::record_event_dropped();
-            }
-
-            // Deliberately not flushing per message. Flushing is a shutdown
-            // concern, and doing it here would serialise the whole stream on
-            // broker acknowledgement.
-        }
-    }
-}
+// A Kafka producer sink used to live here, behind a `kafka` feature. It was
+// removed, and the reason is worth keeping.
+//
+// CI runs `cargo clippy --all-targets --all-features`, so an optional feature
+// is not optional in CI: every platform built the vendored librdkafka on every
+// run, and Windows could not build it at all (`rdkafka-sys` panics with "%1 is
+// not a valid Win32 application"). A dependency that breaks a third of the
+// build matrix has to earn its place, and this one could not: it had never been
+// run against a broker, so nothing here was verified by having it.
+//
+// What it was protecting is unaffected. The schema, the Confluent framing, the
+// encoding, the drop policy, and the BACKWARD compatibility proof in
+// tests/schema_compatibility.rs are all still here and all still tested. `Sink`
+// is the seam: adding a real producer is an implementation of one trait method,
+// and it should land as its own change, on a branch with a broker to test it
+// against.

--- a/crates/vastlint-grpc/src/lib.rs
+++ b/crates/vastlint-grpc/src/lib.rs
@@ -1,0 +1,26 @@
+//! gRPC server for vastlint.
+//!
+//! Serves `openadtech.vastlint.v1` over HTTP/2, with server reflection and
+//! `grpc.health.v1`. The transport layer is a thin adapter: every RPC delegates
+//! to `vastlint-core` and holds no validation logic of its own, so the gRPC
+//! surface and the CLI cannot disagree about what a document means.
+//!
+//! The wire contract lives in `proto/openadtech/vastlint/v1/vastlint.proto` and
+//! is not generated from the Rust types. `buf breaking` guards it in CI.
+
+pub mod convert;
+pub mod deadline;
+pub mod provenance;
+pub mod service;
+
+/// Generated bindings for `openadtech.vastlint.v1`.
+pub mod proto {
+    #![allow(clippy::doc_overindented_list_items)]
+
+    tonic::include_proto!("openadtech.vastlint.v1");
+
+    /// The encoded file descriptor set, served by reflection so that `grpcurl`
+    /// can describe and call this server with no local copy of the proto.
+    pub const FILE_DESCRIPTOR_SET: &[u8] =
+        tonic::include_file_descriptor_set!("vastlint_descriptor");
+}

--- a/crates/vastlint-grpc/src/lib.rs
+++ b/crates/vastlint-grpc/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod config;
 pub mod convert;
 pub mod deadline;
+pub mod events;
 pub mod limit;
 pub mod metrics;
 pub mod provenance;

--- a/crates/vastlint-grpc/src/lib.rs
+++ b/crates/vastlint-grpc/src/lib.rs
@@ -8,9 +8,13 @@
 //! The wire contract lives in `proto/openadtech/vastlint/v1/vastlint.proto` and
 //! is not generated from the Rust types. `buf breaking` guards it in CI.
 
+pub mod config;
 pub mod convert;
 pub mod deadline;
+pub mod limit;
+pub mod metrics;
 pub mod provenance;
+pub mod ratelimit;
 pub mod service;
 
 /// Generated bindings for `openadtech.vastlint.v1`.

--- a/crates/vastlint-grpc/src/limit.rs
+++ b/crates/vastlint-grpc/src/limit.rs
@@ -1,0 +1,554 @@
+//! Adaptive concurrency limiting and load shedding.
+//!
+//! A static thread pool or a fixed concurrency cap is the wrong answer under
+//! variable load: the right number depends on the document mix, the machine,
+//! and what else is running on it, and every one of those changes without
+//! anyone editing a config file. The limit here is discovered from observed
+//! latency instead, using additive-increase multiplicative-decrease, in the
+//! spirit of Netflix's `concurrency-limits`.
+//!
+//! Above the limit the server sheds with `RESOURCE_EXHAUSTED` rather than
+//! queueing. That is the important half. A validator that queues past its
+//! caller's deadline is worse than one that refuses immediately, because the
+//! caller has already lost the auction and the work still consumed capacity
+//! that a servable request needed.
+//!
+//! ## Why a counter and not a semaphore
+//!
+//! The obvious implementation is a `Semaphore` with `try_acquire`. It is not
+//! used, because a semaphore's structure exists to make waiters wait, and this
+//! layer never wants a waiter: a request that cannot run right now is refused,
+//! not parked. Resizing a semaphore's permit count at runtime is also fiddly in
+//! a way that an atomic counter is not, and the counter's one weakness, a small
+//! race where two requests can both observe room for one, is harmless. It
+//! admits an occasional extra request, which is exactly what the next latency
+//! sample will correct.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use tonic::Status;
+use tower::{Layer, Service};
+
+use crate::config::LimitConfig;
+use crate::metrics;
+
+/// Paths that are never limited or shed.
+///
+/// Shedding a health check is actively harmful: a load balancer would pull the
+/// instance out of rotation precisely when it is busy but still serving, which
+/// moves its traffic onto the remaining instances and spreads the overload. The
+/// same argument applies to reflection, which is how tooling discovers the
+/// server at all.
+const EXEMPT_PREFIXES: [&str; 3] = [
+    "/grpc.health.v1.",
+    "/grpc.reflection.v1.",
+    "/grpc.reflection.v1alpha.",
+];
+
+/// The AIMD controller and its in-flight count.
+#[derive(Debug)]
+pub struct AdaptiveLimiter {
+    config: LimitConfig,
+    /// Current concurrency limit. Moves between `config.min` and `config.max`.
+    limit: AtomicUsize,
+    /// Requests currently admitted and not yet finished.
+    inflight: AtomicUsize,
+}
+
+impl AdaptiveLimiter {
+    pub fn new(config: LimitConfig) -> Self {
+        let initial = config.initial.clamp(config.min, config.max);
+        Self {
+            limit: AtomicUsize::new(initial),
+            inflight: AtomicUsize::new(0),
+            config,
+        }
+    }
+
+    pub fn limit(&self) -> usize {
+        self.limit.load(Ordering::Relaxed)
+    }
+
+    pub fn inflight(&self) -> usize {
+        self.inflight.load(Ordering::Relaxed)
+    }
+
+    /// Admits a request, or returns `None` when the server is at its limit.
+    ///
+    /// The returned guard records the outcome when dropped, so a request that
+    /// panics still releases its slot and still feeds the controller. Losing
+    /// in-flight accounting on the error path is how a limiter ratchets itself
+    /// down to the floor and stays there.
+    fn try_admit(self: &Arc<Self>) -> Option<Admitted> {
+        if !self.config.enabled {
+            return Some(Admitted {
+                limiter: Arc::clone(self),
+                started: Instant::now(),
+                counted: false,
+            });
+        }
+
+        let limit = self.limit.load(Ordering::Relaxed);
+        let inflight = self.inflight.fetch_add(1, Ordering::AcqRel);
+
+        if inflight >= limit {
+            self.inflight.fetch_sub(1, Ordering::AcqRel);
+            return None;
+        }
+
+        Some(Admitted {
+            limiter: Arc::clone(self),
+            started: Instant::now(),
+            counted: true,
+        })
+    }
+
+    /// Feeds one completed request back into the controller.
+    ///
+    /// The rule, following Netflix's `AIMDLimit`:
+    ///
+    /// - Latency above the target is evidence of queueing, so decrease
+    ///   multiplicatively.
+    /// - Otherwise increase by one, but *only* when the request ran with the
+    ///   server at or near its limit. Growing on evidence gathered while idle
+    ///   inflates the limit without ever testing it, and the inflated value is
+    ///   then discovered all at once during the next traffic spike.
+    fn sample(&self, latency: Duration, inflight_at_start: usize) {
+        if !self.config.enabled {
+            return;
+        }
+
+        let limit = self.limit.load(Ordering::Relaxed);
+
+        let next = if latency > self.config.target_latency {
+            let decreased = (limit as f64 * self.config.backoff_ratio).floor() as usize;
+            // Always move by at least one, otherwise a backoff ratio close to
+            // 1.0 leaves small limits permanently stuck.
+            decreased.min(limit.saturating_sub(1)).max(self.config.min)
+        } else if inflight_at_start + 1 >= limit {
+            limit.saturating_add(1).min(self.config.max)
+        } else {
+            limit
+        };
+
+        if next != limit {
+            self.limit.store(next, Ordering::Relaxed);
+            metrics::set_concurrency_limit(next);
+        }
+    }
+}
+
+/// An admitted request. Releases its slot and records a sample on drop.
+struct Admitted {
+    limiter: Arc<AdaptiveLimiter>,
+    started: Instant,
+    /// False when the limiter is disabled, in which case nothing was counted on
+    /// the way in and nothing must be uncounted on the way out.
+    counted: bool,
+}
+
+impl Drop for Admitted {
+    fn drop(&mut self) {
+        if !self.counted {
+            return;
+        }
+
+        let inflight_at_start = self.limiter.inflight.fetch_sub(1, Ordering::AcqRel);
+        self.limiter
+            .sample(self.started.elapsed(), inflight_at_start.saturating_sub(1));
+    }
+}
+
+/// Tower layer applying the limiter to every gRPC call.
+#[derive(Debug, Clone)]
+pub struct AdaptiveConcurrencyLayer {
+    limiter: Arc<AdaptiveLimiter>,
+}
+
+impl AdaptiveConcurrencyLayer {
+    pub fn new(limiter: Arc<AdaptiveLimiter>) -> Self {
+        Self { limiter }
+    }
+}
+
+impl<S> Layer<S> for AdaptiveConcurrencyLayer {
+    type Service = AdaptiveConcurrency<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AdaptiveConcurrency {
+            inner,
+            limiter: Arc::clone(&self.limiter),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AdaptiveConcurrency<S> {
+    inner: S,
+    limiter: Arc<AdaptiveLimiter>,
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for AdaptiveConcurrency<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: http::Request<ReqBody>) -> Self::Future {
+        let exempt = EXEMPT_PREFIXES
+            .iter()
+            .any(|prefix| request.uri().path().starts_with(prefix));
+
+        // The standard tower dance: `poll_ready` was called on `self`, so the
+        // reservation belongs to this instance and the clone is what must be
+        // left behind for the next call.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        if exempt {
+            return Box::pin(async move { inner.call(request).await });
+        }
+
+        let Some(permit) = self.limiter.try_admit() else {
+            metrics::record_shed();
+            let response = Status::resource_exhausted(
+                "server is at its concurrency limit; retry with backoff",
+            )
+            .into_http();
+            return Box::pin(async move { Ok(response) });
+        };
+
+        Box::pin(async move {
+            let response = inner.call(request).await;
+            // Dropped here rather than earlier, so the latency sample covers
+            // the whole call including response encoding.
+            drop(permit);
+            response
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> LimitConfig {
+        LimitConfig {
+            enabled: true,
+            initial: 10,
+            min: 2,
+            max: 100,
+            target_latency: Duration::from_millis(50),
+            backoff_ratio: 0.9,
+        }
+    }
+
+    fn limiter(config: LimitConfig) -> Arc<AdaptiveLimiter> {
+        Arc::new(AdaptiveLimiter::new(config))
+    }
+
+    #[test]
+    fn admits_up_to_the_limit_then_sheds() {
+        let limiter = limiter(LimitConfig {
+            initial: 3,
+            ..config()
+        });
+
+        let permits: Vec<_> = (0..3).map(|_| limiter.try_admit()).collect();
+        assert!(
+            permits.iter().all(Option::is_some),
+            "first three are admitted"
+        );
+        assert_eq!(limiter.inflight(), 3);
+
+        assert!(limiter.try_admit().is_none(), "the fourth is shed");
+        // A shed request must not leave its slot occupied, or the limiter
+        // ratchets down to nothing under sustained overload.
+        assert_eq!(limiter.inflight(), 3);
+    }
+
+    #[test]
+    fn releasing_a_permit_frees_a_slot() {
+        // min must come down too: the initial value is clamped into range, so
+        // an initial of 1 under a floor of 2 would silently be a limit of 2.
+        let limiter = limiter(LimitConfig {
+            initial: 1,
+            min: 1,
+            ..config()
+        });
+
+        let permit = limiter.try_admit().expect("admitted");
+        assert!(limiter.try_admit().is_none());
+
+        drop(permit);
+        assert_eq!(limiter.inflight(), 0);
+        assert!(limiter.try_admit().is_some(), "the slot is reusable");
+    }
+
+    #[test]
+    fn slow_requests_decrease_the_limit() {
+        let limiter = limiter(config());
+        let before = limiter.limit();
+
+        limiter.sample(Duration::from_millis(500), before);
+
+        assert!(
+            limiter.limit() < before,
+            "latency past the target should back the limit off, got {} from {before}",
+            limiter.limit()
+        );
+    }
+
+    #[test]
+    fn fast_requests_at_the_limit_increase_it() {
+        let limiter = limiter(config());
+        let before = limiter.limit();
+
+        // Ran with the server saturated: this is evidence the limit is too low.
+        limiter.sample(Duration::from_millis(1), before - 1);
+
+        assert_eq!(limiter.limit(), before + 1);
+    }
+
+    /// The trap: growing on every fast request inflates the limit while the
+    /// server is idle, so the inflated value is never tested until a spike
+    /// arrives and discovers it all at once.
+    #[test]
+    fn fast_requests_below_the_limit_do_not_increase_it() {
+        let limiter = limiter(config());
+        let before = limiter.limit();
+
+        limiter.sample(Duration::from_millis(1), 0);
+
+        assert_eq!(limiter.limit(), before, "an idle server proves nothing");
+    }
+
+    #[test]
+    fn the_limit_never_falls_below_the_floor() {
+        let limiter = limiter(LimitConfig {
+            initial: 3,
+            min: 2,
+            backoff_ratio: 0.1,
+            ..config()
+        });
+
+        for _ in 0..50 {
+            limiter.sample(Duration::from_secs(5), 0);
+        }
+
+        assert_eq!(limiter.limit(), 2, "the floor holds");
+    }
+
+    #[test]
+    fn the_limit_never_exceeds_the_ceiling() {
+        let limiter = limiter(LimitConfig {
+            initial: 8,
+            max: 10,
+            ..config()
+        });
+
+        for _ in 0..50 {
+            let at_limit = limiter.limit() - 1;
+            limiter.sample(Duration::from_millis(1), at_limit);
+        }
+
+        assert_eq!(limiter.limit(), 10, "the ceiling holds");
+    }
+
+    /// A backoff ratio near 1.0 rounds to no change at small limits, which
+    /// would leave an overloaded server unable to back off at all.
+    #[test]
+    fn backoff_always_moves_by_at_least_one() {
+        let limiter = limiter(LimitConfig {
+            initial: 5,
+            min: 1,
+            backoff_ratio: 0.99,
+            ..config()
+        });
+
+        limiter.sample(Duration::from_secs(1), 0);
+        assert_eq!(limiter.limit(), 4);
+    }
+
+    #[test]
+    fn a_disabled_limiter_admits_everything() {
+        let limiter = limiter(LimitConfig {
+            enabled: false,
+            initial: 1,
+            ..config()
+        });
+
+        let permits: Vec<_> = (0..100).map(|_| limiter.try_admit()).collect();
+        assert!(permits.iter().all(Option::is_some));
+        // Nothing is counted while disabled, so nothing can be miscounted on
+        // the way back out.
+        assert_eq!(limiter.inflight(), 0);
+    }
+
+    #[test]
+    fn a_disabled_limiter_never_moves_its_limit() {
+        let limiter = limiter(LimitConfig {
+            enabled: false,
+            ..config()
+        });
+        let before = limiter.limit();
+
+        limiter.sample(Duration::from_secs(10), 1000);
+
+        assert_eq!(limiter.limit(), before);
+    }
+
+    #[test]
+    fn the_initial_limit_is_clamped_into_range() {
+        let limiter = AdaptiveLimiter::new(LimitConfig {
+            initial: 5_000,
+            max: 100,
+            ..config()
+        });
+        assert_eq!(limiter.limit(), 100);
+
+        let limiter = AdaptiveLimiter::new(LimitConfig {
+            initial: 1,
+            min: 4,
+            ..config()
+        });
+        assert_eq!(limiter.limit(), 4);
+    }
+
+    /// An inner service that never completes, so the first request holds its
+    /// slot for as long as the test needs. Deterministic in a way that firing
+    /// concurrent real requests and hoping for contention is not.
+    ///
+    /// Written out rather than built with `service_fn`, because the layer needs
+    /// `Future: Send + 'static` and an opaque `impl Service` return type does
+    /// not carry that through.
+    #[derive(Clone)]
+    struct NeverCompletes;
+
+    impl Service<http::Request<()>> for NeverCompletes {
+        type Response = http::Response<()>;
+        type Error = std::convert::Infallible;
+        type Future = std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+        >;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _request: http::Request<()>) -> Self::Future {
+            Box::pin(async {
+                std::future::pending::<()>().await;
+                unreachable!("the test never lets this resolve")
+            })
+        }
+    }
+
+    fn request(path: &str) -> http::Request<()> {
+        http::Request::builder()
+            .uri(format!("http://localhost{path}"))
+            .body(())
+            .expect("valid request")
+    }
+
+    /// The status code matters as much as the refusal. `RESOURCE_EXHAUSTED` is
+    /// the one clients are expected to retry with backoff; returning
+    /// `UNAVAILABLE` or an HTTP 503 would push well-behaved clients into
+    /// immediate retries and make an overloaded server worse.
+    #[tokio::test]
+    async fn the_layer_sheds_with_resource_exhausted() {
+        let limiter = limiter(LimitConfig {
+            initial: 1,
+            min: 1,
+            max: 1,
+            ..config()
+        });
+        let mut service = AdaptiveConcurrencyLayer::new(Arc::clone(&limiter)).layer(NeverCompletes);
+
+        // Held, not awaited: dropping it would release the slot.
+        let _occupied = service.call(request("/openadtech.vastlint.v1.VastlintService/Validate"));
+        assert_eq!(limiter.inflight(), 1);
+
+        let shed = service
+            .call(request("/openadtech.vastlint.v1.VastlintService/Validate"))
+            .await
+            .expect("shedding is a response, not a transport error");
+
+        assert_eq!(
+            shed.headers()
+                .get("grpc-status")
+                .map(|v| v.to_str().unwrap()),
+            // 8 is RESOURCE_EXHAUSTED.
+            Some("8"),
+            "a shed request must carry a gRPC status the caller can act on"
+        );
+    }
+
+    /// Shedding a health check would make an overloaded instance look dead, so a
+    /// load balancer would pull it out of rotation and move its traffic onto
+    /// instances that are equally busy.
+    #[tokio::test]
+    async fn health_checks_are_served_while_shedding() {
+        let limiter = limiter(LimitConfig {
+            initial: 1,
+            min: 1,
+            max: 1,
+            ..config()
+        });
+        let mut service = AdaptiveConcurrencyLayer::new(Arc::clone(&limiter)).layer(NeverCompletes);
+
+        let _occupied = service.call(request("/openadtech.vastlint.v1.VastlintService/Validate"));
+
+        // If the health path were shed, this would resolve immediately with a
+        // status. Because it is exempt it reaches the inner service and hangs,
+        // which is what the timeout observes.
+        let health = tokio::time::timeout(
+            Duration::from_millis(50),
+            service.call(request("/grpc.health.v1.Health/Check")),
+        )
+        .await;
+
+        assert!(
+            health.is_err(),
+            "the health path should have reached the inner service rather than being shed"
+        );
+    }
+
+    #[test]
+    fn health_and_reflection_paths_are_exempt() {
+        for path in [
+            "/grpc.health.v1.Health/Check",
+            "/grpc.health.v1.Health/Watch",
+            "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
+            "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+        ] {
+            assert!(
+                EXEMPT_PREFIXES
+                    .iter()
+                    .any(|prefix| path.starts_with(prefix)),
+                "{path} should be exempt from shedding"
+            );
+        }
+
+        assert!(
+            !EXEMPT_PREFIXES.iter().any(|prefix| {
+                "/openadtech.vastlint.v1.VastlintService/Validate".starts_with(prefix)
+            }),
+            "the validation path is not exempt"
+        );
+    }
+}

--- a/crates/vastlint-grpc/src/limit.rs
+++ b/crates/vastlint-grpc/src/limit.rs
@@ -48,6 +48,25 @@ const EXEMPT_PREFIXES: [&str; 3] = [
     "/grpc.reflection.v1alpha.",
 ];
 
+/// Streaming calls, which this layer must not govern.
+///
+/// This layer works per HTTP request, and a bidirectional stream is one HTTP
+/// request that lives for as long as the client keeps it open. Two things go
+/// wrong if it is treated like any other call.
+///
+/// It would hold one concurrency slot for the whole stream, so a handful of
+/// idle long-lived streams could exhaust the limit while doing no work at all.
+///
+/// Worse, the latency sample taken when the stream ends would be the stream's
+/// entire lifetime. A sixty-second stream reports sixty seconds, which is
+/// enormously past any sane target, so every stream that ends drives the limit
+/// down multiplicatively. A server with steady streaming traffic would ratchet
+/// itself to the floor and shed unary requests it could serve easily.
+///
+/// Admission for streams happens per message inside the handler instead, where
+/// the unit of work actually is one document.
+const UNGOVERNED_PATHS: [&str; 1] = ["/openadtech.vastlint.v1.VastlintService/ValidateStream"];
+
 /// The AIMD controller and its in-flight count.
 #[derive(Debug)]
 pub struct AdaptiveLimiter {
@@ -82,7 +101,10 @@ impl AdaptiveLimiter {
     /// panics still releases its slot and still feeds the controller. Losing
     /// in-flight accounting on the error path is how a limiter ratchets itself
     /// down to the floor and stays there.
-    fn try_admit(self: &Arc<Self>) -> Option<Admitted> {
+    ///
+    /// Public because the streaming handler admits per message rather than per
+    /// call, for the reasons in [`UNGOVERNED_PATHS`].
+    pub fn try_admit(self: &Arc<Self>) -> Option<Admitted> {
         if !self.config.enabled {
             return Some(Admitted {
                 limiter: Arc::clone(self),
@@ -142,7 +164,7 @@ impl AdaptiveLimiter {
 }
 
 /// An admitted request. Releases its slot and records a sample on drop.
-struct Admitted {
+pub struct Admitted {
     limiter: Arc<AdaptiveLimiter>,
     started: Instant,
     /// False when the limiter is disabled, in which case nothing was counted on
@@ -209,9 +231,11 @@ where
     }
 
     fn call(&mut self, request: http::Request<ReqBody>) -> Self::Future {
+        let path = request.uri().path();
         let exempt = EXEMPT_PREFIXES
             .iter()
-            .any(|prefix| request.uri().path().starts_with(prefix));
+            .any(|prefix| path.starts_with(prefix))
+            || UNGOVERNED_PATHS.contains(&path);
 
         // The standard tower dance: `poll_ready` was called on `self`, so the
         // reservation belongs to this instance and the clone is what must be
@@ -525,6 +549,69 @@ mod tests {
         assert!(
             health.is_err(),
             "the health path should have reached the inner service rather than being shed"
+        );
+    }
+
+    /// The bug this guards is subtle and would have been invisible in
+    /// production until streaming traffic arrived: a stream is one HTTP request
+    /// that lives for minutes, so treating it like a unary call means its
+    /// latency sample is its entire lifetime. Every stream that ended would
+    /// drive the limit down multiplicatively until unary callers were being
+    /// shed by a server doing almost nothing.
+    #[test]
+    fn a_long_lived_stream_cannot_poison_the_limit() {
+        let limiter = limiter(config());
+        let before = limiter.limit();
+
+        // What the layer would have recorded for a one-minute stream.
+        limiter.sample(Duration::from_secs(60), 0);
+        let after_one = limiter.limit();
+
+        for _ in 0..20 {
+            limiter.sample(Duration::from_secs(60), 0);
+        }
+
+        assert!(
+            after_one < before,
+            "sanity: a sample that long does drive the limit down"
+        );
+        assert_eq!(
+            limiter.limit(),
+            config().min,
+            "which is exactly why the streaming path must not be sampled by the layer"
+        );
+
+        assert!(
+            UNGOVERNED_PATHS.contains(&"/openadtech.vastlint.v1.VastlintService/ValidateStream"),
+            "the streaming path must be ungoverned by this layer"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_streaming_path_is_not_shed_by_the_layer() {
+        let limiter = limiter(LimitConfig {
+            initial: 1,
+            min: 1,
+            max: 1,
+            ..config()
+        });
+        let mut service = AdaptiveConcurrencyLayer::new(Arc::clone(&limiter)).layer(NeverCompletes);
+
+        let _occupied = service.call(request("/openadtech.vastlint.v1.VastlintService/Validate"));
+
+        // Reaching the inner service means hanging, which the timeout observes.
+        // Being shed would resolve immediately with a status.
+        let streaming = tokio::time::timeout(
+            Duration::from_millis(50),
+            service.call(request(
+                "/openadtech.vastlint.v1.VastlintService/ValidateStream",
+            )),
+        )
+        .await;
+
+        assert!(
+            streaming.is_err(),
+            "streams admit per message inside the handler, not per call here"
         );
     }
 

--- a/crates/vastlint-grpc/src/limit.rs
+++ b/crates/vastlint-grpc/src/limit.rs
@@ -103,7 +103,9 @@ impl AdaptiveLimiter {
     /// down to the floor and stays there.
     ///
     /// Public because the streaming handler admits per message rather than per
-    /// call, for the reasons in [`UNGOVERNED_PATHS`].
+    /// call, for the reasons on the private `UNGOVERNED_PATHS` constant: a
+    /// stream is one HTTP request that lives for minutes, so sampling it as a
+    /// single call reports its whole lifetime as one latency measurement.
     pub fn try_admit(self: &Arc<Self>) -> Option<Admitted> {
         if !self.config.enabled {
             return Some(Admitted {

--- a/crates/vastlint-grpc/src/main.rs
+++ b/crates/vastlint-grpc/src/main.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use mimalloc::MiMalloc;
 use tonic::transport::Server;
 use vastlint_grpc::config::Config;
+use vastlint_grpc::events::{NullSink, Publisher, Sink};
 use vastlint_grpc::limit::{AdaptiveConcurrencyLayer, AdaptiveLimiter};
 use vastlint_grpc::metrics;
 use vastlint_grpc::proto::vastlint_service_server::VastlintServiceServer;
@@ -81,6 +82,20 @@ async fn serve(config: Config) -> Result<(), Box<dyn std::error::Error>> {
         .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
         .build_v1alpha()?;
 
+    // Built before anything is bound or printed. A misconfigured results stream
+    // should fail while the process is still obviously starting up, not after a
+    // banner that says the server is listening.
+    let publisher = if config.events.enabled {
+        let sink: Arc<dyn Sink> = build_sink(&config)?;
+        Some(Arc::new(Publisher::spawn(
+            sink,
+            config.events.buffer,
+            config.events.schema_id,
+        )))
+    } else {
+        None
+    };
+
     if let Some(metrics_addr) = config.metrics_addr {
         tokio::spawn(async move {
             if let Err(error) = metrics::serve(metrics_addr).await {
@@ -99,10 +114,13 @@ async fn serve(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     // concurrency slot for its whole lifetime and report its entire duration as
     // a latency sample, driving the limit to the floor. Admission for streams
     // happens per message instead.
-    let vastlint = VastlintServiceServer::new(
-        VastlintApi::new().with_limiter(Arc::clone(&limiter), config.stream_buffer),
-    )
-    .max_decoding_message_size(config.max_message_bytes);
+    let mut api = VastlintApi::new().with_limiter(Arc::clone(&limiter), config.stream_buffer);
+    if let Some(publisher) = publisher {
+        api = api.with_publisher(publisher, config.events.schema_id);
+    }
+
+    let vastlint =
+        VastlintServiceServer::new(api).max_decoding_message_size(config.max_message_bytes);
 
     let mut server = Server::builder();
     if let Some(bytes) = config.stream_window_bytes {
@@ -130,6 +148,45 @@ async fn serve(config: Config) -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     Ok(())
+}
+
+/// Chooses where validation events go.
+///
+/// With the `kafka` feature off, or with no brokers configured, events are
+/// still built and encoded and then discarded. That is deliberate: it keeps the
+/// encoding path exercised in every deployment, so a schema problem surfaces
+/// wherever the server runs rather than only where a broker happens to exist.
+fn build_sink(config: &Config) -> Result<Arc<dyn Sink>, Box<dyn std::error::Error>> {
+    if config.events.brokers.is_empty() {
+        eprintln!("events: enabled with no brokers, encoding and discarding");
+        return Ok(Arc::new(NullSink::default()));
+    }
+
+    #[cfg(feature = "kafka")]
+    {
+        let sink = vastlint_grpc::events::kafka::KafkaSink::new(
+            &config.events.brokers,
+            &config.events.topic,
+        )?;
+        eprintln!(
+            "events: publishing to {} topic {}",
+            config.events.brokers, config.events.topic
+        );
+        Ok(Arc::new(sink))
+    }
+
+    #[cfg(not(feature = "kafka"))]
+    {
+        // Refusing rather than silently discarding. An operator who set brokers
+        // expects records to arrive, and a binary built without the feature
+        // cannot deliver them. Starting anyway would look like success.
+        Err(format!(
+            "VASTLINT_KAFKA_BROKERS is set to {:?} but this binary was built without the \
+             `kafka` feature; rebuild with --features kafka or unset the brokers",
+            config.events.brokers
+        )
+        .into())
+    }
 }
 
 /// Prints the effective configuration at startup.

--- a/crates/vastlint-grpc/src/main.rs
+++ b/crates/vastlint-grpc/src/main.rs
@@ -1,0 +1,87 @@
+//! vastlint gRPC server.
+//!
+//! ```text
+//! VASTLINT_GRPC_ADDR=0.0.0.0:50051 vastlint-grpc
+//! grpcurl -plaintext localhost:50051 list
+//! ```
+//!
+//! Reflection is enabled, so `grpcurl` needs no local copy of the proto, and
+//! `grpc.health.v1` is served for readiness probes.
+
+use std::net::SocketAddr;
+
+use mimalloc::MiMalloc;
+use tonic::transport::Server;
+use vastlint_grpc::proto::vastlint_service_server::VastlintServiceServer;
+use vastlint_grpc::proto::FILE_DESCRIPTOR_SET;
+use vastlint_grpc::service::VastlintApi;
+
+/// Validation builds an owned document tree per call, so under concurrency the
+/// system allocator's shared free list becomes the bottleneck before the
+/// validator does. Same reasoning as vastlint-mcp.
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+/// Default listen address. Binds all interfaces because the deployment target
+/// is a container.
+const DEFAULT_ADDR: &str = "0.0.0.0:50051";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr: SocketAddr = std::env::var("VASTLINT_GRPC_ADDR")
+        .unwrap_or_else(|_| DEFAULT_ADDR.to_string())
+        .parse()?;
+
+    let service = VastlintApi::new();
+
+    // Health reporting. Marked serving immediately: the rule catalog is static
+    // and there is no warm-up, so there is no state in which the process is up
+    // but unable to answer.
+    let (health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter
+        .set_serving::<VastlintServiceServer<VastlintApi>>()
+        .await;
+
+    // v1 and v1alpha are both registered. grpcurl and several older tools still
+    // speak v1alpha, and serving only v1 makes the server look like it has no
+    // reflection at all to those clients.
+    //
+    // The health descriptor is registered alongside vastlint's own. Reflection
+    // only reports what is in its descriptor pool, so without this the health
+    // service is served but undiscoverable: `grpcurl list` omits it and calling
+    // it fails with "target server does not expose service grpc.health.v1.Health"
+    // even though it is right there. Anything that probes by reflection rather
+    // than by a vendored copy of the health proto would conclude the server has
+    // no health checking.
+    let reflection_v1 = tonic_reflection::server::Builder::configure()
+        .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+        .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
+        .build_v1()?;
+    let reflection_v1alpha = tonic_reflection::server::Builder::configure()
+        .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+        .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
+        .build_v1alpha()?;
+
+    eprintln!(
+        "vastlint-grpc {} listening on {addr}",
+        env!("CARGO_PKG_VERSION")
+    );
+    eprintln!("catalog {}", vastlint_grpc::provenance::catalog_digest());
+
+    Server::builder()
+        .add_service(health_service)
+        .add_service(reflection_v1)
+        .add_service(reflection_v1alpha)
+        .add_service(VastlintServiceServer::new(service))
+        .serve_with_shutdown(addr, shutdown())
+        .await?;
+
+    Ok(())
+}
+
+/// Stops accepting on SIGINT so in-flight requests finish rather than being cut
+/// off mid-response. Kubernetes sends SIGTERM, which is handled the same way.
+async fn shutdown() {
+    let _ = tokio::signal::ctrl_c().await;
+    eprintln!("shutting down");
+}

--- a/crates/vastlint-grpc/src/main.rs
+++ b/crates/vastlint-grpc/src/main.rs
@@ -152,41 +152,26 @@ async fn serve(config: Config) -> Result<(), Box<dyn std::error::Error>> {
 
 /// Chooses where validation events go.
 ///
-/// With the `kafka` feature off, or with no brokers configured, events are
-/// still built and encoded and then discarded. That is deliberate: it keeps the
-/// encoding path exercised in every deployment, so a schema problem surfaces
-/// wherever the server runs rather than only where a broker happens to exist.
+/// With no brokers configured, events are still built, encoded, and discarded.
+/// That is deliberate: it keeps the encoding path exercised in every
+/// deployment, so a schema problem surfaces wherever the server runs rather
+/// than only where a broker happens to exist.
 fn build_sink(config: &Config) -> Result<Arc<dyn Sink>, Box<dyn std::error::Error>> {
     if config.events.brokers.is_empty() {
         eprintln!("events: enabled with no brokers, encoding and discarding");
         return Ok(Arc::new(NullSink::default()));
     }
 
-    #[cfg(feature = "kafka")]
-    {
-        let sink = vastlint_grpc::events::kafka::KafkaSink::new(
-            &config.events.brokers,
-            &config.events.topic,
-        )?;
-        eprintln!(
-            "events: publishing to {} topic {}",
-            config.events.brokers, config.events.topic
-        );
-        Ok(Arc::new(sink))
-    }
-
-    #[cfg(not(feature = "kafka"))]
-    {
-        // Refusing rather than silently discarding. An operator who set brokers
-        // expects records to arrive, and a binary built without the feature
-        // cannot deliver them. Starting anyway would look like success.
-        Err(format!(
-            "VASTLINT_KAFKA_BROKERS is set to {:?} but this binary was built without the \
-             `kafka` feature; rebuild with --features kafka or unset the brokers",
-            config.events.brokers
-        )
-        .into())
-    }
+    // Refusing rather than silently discarding. An operator who set brokers
+    // expects records to arrive, and this binary has no producer to deliver
+    // them with. Starting anyway would look like success and lose every event.
+    Err(format!(
+        "VASTLINT_KAFKA_BROKERS is set to {:?} but this build has no Kafka producer. \
+         Events are encoded and discarded; unset the brokers to run that way \
+         deliberately, or implement events::Sink against a broker you can test.",
+        config.events.brokers
+    )
+    .into())
 }
 
 /// Prints the effective configuration at startup.

--- a/crates/vastlint-grpc/src/main.rs
+++ b/crates/vastlint-grpc/src/main.rs
@@ -3,17 +3,22 @@
 //! ```text
 //! VASTLINT_GRPC_ADDR=0.0.0.0:50051 vastlint-grpc
 //! grpcurl -plaintext localhost:50051 list
+//! curl localhost:9090/metrics
 //! ```
 //!
 //! Reflection is enabled, so `grpcurl` needs no local copy of the proto, and
 //! `grpc.health.v1` is served for readiness probes.
 
-use std::net::SocketAddr;
+use std::sync::Arc;
 
 use mimalloc::MiMalloc;
 use tonic::transport::Server;
+use vastlint_grpc::config::Config;
+use vastlint_grpc::limit::{AdaptiveConcurrencyLayer, AdaptiveLimiter};
+use vastlint_grpc::metrics;
 use vastlint_grpc::proto::vastlint_service_server::VastlintServiceServer;
 use vastlint_grpc::proto::FILE_DESCRIPTOR_SET;
+use vastlint_grpc::ratelimit::{RateLimitLayer, RateLimiter};
 use vastlint_grpc::service::VastlintApi;
 
 /// Validation builds an owned document tree per call, so under concurrency the
@@ -22,17 +27,31 @@ use vastlint_grpc::service::VastlintApi;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-/// Default listen address. Binds all interfaces because the deployment target
-/// is a container.
-const DEFAULT_ADDR: &str = "0.0.0.0:50051";
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::from_env()?;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr: SocketAddr = std::env::var("VASTLINT_GRPC_ADDR")
-        .unwrap_or_else(|_| DEFAULT_ADDR.to_string())
-        .parse()?;
+    // The runtime is built by hand rather than through `#[tokio::main]` so the
+    // blocking pool can be sized. That pool is where validation actually runs,
+    // and its default ceiling of 512 threads is sized for blocking I/O, not for
+    // CPU-bound work. Leaving it at the default means 512 concurrent
+    // validations on a machine with a dozen cores, which does not raise
+    // throughput, only latency and context switches, and it puts the real
+    // admission decision somewhere nobody configured.
+    let mut runtime = tokio::runtime::Builder::new_multi_thread();
+    runtime
+        .enable_all()
+        .max_blocking_threads(config.blocking_threads);
+    if let Some(threads) = config.worker_threads {
+        runtime.worker_threads(threads);
+    }
 
-    let service = VastlintApi::new();
+    runtime.build()?.block_on(serve(config))
+}
+
+async fn serve(config: Config) -> Result<(), Box<dyn std::error::Error>> {
+    let limiter = Arc::new(AdaptiveLimiter::new(config.limit.clone()));
+    let rate_limiter = Arc::new(RateLimiter::new(config.rate_limit.clone()));
+    metrics::set_concurrency_limit(limiter.limit());
 
     // Health reporting. Marked serving immediately: the rule catalog is static
     // and there is no warm-up, so there is no state in which the process is up
@@ -62,21 +81,86 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
         .build_v1alpha()?;
 
-    eprintln!(
-        "vastlint-grpc {} listening on {addr}",
-        env!("CARGO_PKG_VERSION")
-    );
-    eprintln!("catalog {}", vastlint_grpc::provenance::catalog_digest());
+    if let Some(metrics_addr) = config.metrics_addr {
+        tokio::spawn(async move {
+            if let Err(error) = metrics::serve(metrics_addr).await {
+                eprintln!("metrics endpoint stopped: {error}");
+            }
+        });
+        eprintln!("metrics on http://{metrics_addr}/metrics");
+    }
+
+    banner(&config, &limiter);
+
+    // A message cap on the decoder, not just on the handler. Rejecting a 40 MB
+    // body after decoding it has already paid the cost the cap exists to avoid.
+    let vastlint = VastlintServiceServer::new(VastlintApi::new())
+        .max_decoding_message_size(config.max_message_bytes);
 
     Server::builder()
+        // Rate limiting sits outside the concurrency limiter on purpose. A
+        // caller over its allowance should be refused before it can occupy a
+        // concurrency slot, otherwise one client in a retry storm crowds out
+        // everyone else while staying under the aggregate limit.
+        .layer(RateLimitLayer::new(
+            Arc::clone(&rate_limiter),
+            config.caller_header.clone(),
+        ))
+        .layer(AdaptiveConcurrencyLayer::new(Arc::clone(&limiter)))
         .add_service(health_service)
         .add_service(reflection_v1)
         .add_service(reflection_v1alpha)
-        .add_service(VastlintServiceServer::new(service))
-        .serve_with_shutdown(addr, shutdown())
+        .add_service(vastlint)
+        .serve_with_shutdown(config.addr, shutdown())
         .await?;
 
     Ok(())
+}
+
+/// Prints the effective configuration at startup.
+///
+/// Every value that changes how the server behaves under load, printed once, so
+/// that a latency graph can be matched to the settings that produced it. An
+/// experiment whose configuration was never recorded is an anecdote.
+fn banner(config: &Config, limiter: &AdaptiveLimiter) {
+    eprintln!(
+        "vastlint-grpc {} listening on {}",
+        env!("CARGO_PKG_VERSION"),
+        config.addr
+    );
+    eprintln!("catalog {}", vastlint_grpc::provenance::catalog_digest());
+
+    if config.limit.enabled {
+        eprintln!(
+            "concurrency limit: adaptive, starting at {} in [{}, {}], target latency {:?}, backoff {}",
+            limiter.limit(),
+            config.limit.min,
+            config.limit.max,
+            config.limit.target_latency,
+            config.limit.backoff_ratio,
+        );
+    } else {
+        eprintln!("concurrency limit: DISABLED, no shedding");
+    }
+
+    if config.rate_limit.per_second > 0 {
+        eprintln!(
+            "rate limit: {}/s per caller, burst {}, identified by {}",
+            config.rate_limit.per_second, config.rate_limit.burst, config.caller_header,
+        );
+    } else {
+        eprintln!("rate limit: disabled");
+    }
+
+    eprintln!("max message size: {} bytes", config.max_message_bytes);
+    eprintln!(
+        "validation threads: {} ({} async workers)",
+        config.blocking_threads,
+        config
+            .worker_threads
+            .map(|threads| threads.to_string())
+            .unwrap_or_else(|| "default".to_string())
+    );
 }
 
 /// Stops accepting on SIGINT so in-flight requests finish rather than being cut

--- a/crates/vastlint-grpc/src/main.rs
+++ b/crates/vastlint-grpc/src/main.rs
@@ -94,10 +94,25 @@ async fn serve(config: Config) -> Result<(), Box<dyn std::error::Error>> {
 
     // A message cap on the decoder, not just on the handler. Rejecting a 40 MB
     // body after decoding it has already paid the cost the cap exists to avoid.
-    let vastlint = VastlintServiceServer::new(VastlintApi::new())
-        .max_decoding_message_size(config.max_message_bytes);
+    // The streaming handler gets the limiter directly, because streams are
+    // exempt from the tower layer: one long-lived stream would otherwise hold a
+    // concurrency slot for its whole lifetime and report its entire duration as
+    // a latency sample, driving the limit to the floor. Admission for streams
+    // happens per message instead.
+    let vastlint = VastlintServiceServer::new(
+        VastlintApi::new().with_limiter(Arc::clone(&limiter), config.stream_buffer),
+    )
+    .max_decoding_message_size(config.max_message_bytes);
 
-    Server::builder()
+    let mut server = Server::builder();
+    if let Some(bytes) = config.stream_window_bytes {
+        server = server.initial_stream_window_size(bytes);
+    }
+    if let Some(bytes) = config.connection_window_bytes {
+        server = server.initial_connection_window_size(bytes);
+    }
+
+    server
         // Rate limiting sits outside the concurrency limiter on purpose. A
         // caller over its allowance should be refused before it can occupy a
         // concurrency slot, otherwise one client in a retry storm crowds out
@@ -153,6 +168,18 @@ fn banner(config: &Config, limiter: &AdaptiveLimiter) {
     }
 
     eprintln!("max message size: {} bytes", config.max_message_bytes);
+    eprintln!(
+        "stream buffer: {} messages in flight, windows {}/{}",
+        config.stream_buffer,
+        config
+            .stream_window_bytes
+            .map(|bytes| bytes.to_string())
+            .unwrap_or_else(|| "default".to_string()),
+        config
+            .connection_window_bytes
+            .map(|bytes| bytes.to_string())
+            .unwrap_or_else(|| "default".to_string()),
+    );
     eprintln!(
         "validation threads: {} ({} async workers)",
         config.blocking_threads,

--- a/crates/vastlint-grpc/src/metrics.rs
+++ b/crates/vastlint-grpc/src/metrics.rs
@@ -1,0 +1,249 @@
+//! Prometheus instrumentation and the `/metrics` endpoint.
+//!
+//! What is measured is chosen to answer one question: is the server keeping its
+//! promise, and if not, which part broke. That means the shed count and the
+//! current concurrency limit sit alongside latency, because a p99 that looks
+//! healthy while the shed rate climbs is a server that got fast by refusing
+//! work.
+//!
+//! ## On percentiles from bucketed histograms
+//!
+//! Prometheus histograms give quantiles by interpolating between bucket edges,
+//! so a p999 is only as good as the buckets around it. The buckets below are
+//! chosen against measured behaviour rather than left at the library defaults,
+//! whose lowest edge of 5ms would put every single-tag validation in the first
+//! bucket and make every quantile a straight-line guess.
+//!
+//! For the load experiment the client measures its own latencies with an HDR
+//! histogram, which has no bucket-choice problem. These metrics are for
+//! operating the server; that one is for the claim.
+
+use std::net::SocketAddr;
+use std::sync::OnceLock;
+
+use prometheus::{
+    Encoder, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry,
+    TextEncoder,
+};
+
+/// Latency buckets in seconds, spanning the measured range of the validator.
+///
+/// vastlint benchmarks at 363µs light and 2,104µs heavy per tag, so the
+/// interesting region is roughly 100µs to 10ms, with the tail above it existing
+/// to distinguish "slow" from "queueing".
+const LATENCY_BUCKETS: &[f64] = &[
+    0.000_1, 0.000_25, 0.000_5, 0.001, 0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.5,
+    1.0, 2.5,
+];
+
+struct Metrics {
+    registry: Registry,
+    requests: IntCounterVec,
+    latency: HistogramVec,
+    shed: IntCounter,
+    rate_limited: IntCounter,
+    concurrency_limit: IntGauge,
+}
+
+static METRICS: OnceLock<Metrics> = OnceLock::new();
+
+fn metrics() -> &'static Metrics {
+    METRICS.get_or_init(|| {
+        let registry = Registry::new();
+
+        let requests = IntCounterVec::new(
+            Opts::new(
+                "vastlint_grpc_requests_total",
+                "gRPC requests completed, by method and resulting status code",
+            ),
+            &["method", "status"],
+        )
+        .expect("valid metric definition");
+
+        let latency = HistogramVec::new(
+            HistogramOpts::new(
+                "vastlint_grpc_request_duration_seconds",
+                "Server-side handling time, by method",
+            )
+            .buckets(LATENCY_BUCKETS.to_vec()),
+            &["method"],
+        )
+        .expect("valid metric definition");
+
+        let shed = IntCounter::new(
+            "vastlint_grpc_shed_total",
+            "Requests refused with RESOURCE_EXHAUSTED because the server was at its concurrency limit",
+        )
+        .expect("valid metric definition");
+
+        let rate_limited = IntCounter::new(
+            "vastlint_grpc_rate_limited_total",
+            "Requests refused with RESOURCE_EXHAUSTED because the caller exceeded its rate limit",
+        )
+        .expect("valid metric definition");
+
+        let concurrency_limit = IntGauge::new(
+            "vastlint_grpc_concurrency_limit",
+            "Current adaptive concurrency limit",
+        )
+        .expect("valid metric definition");
+
+        registry.register(Box::new(requests.clone())).expect("unique metric");
+        registry.register(Box::new(latency.clone())).expect("unique metric");
+        registry.register(Box::new(shed.clone())).expect("unique metric");
+        registry
+            .register(Box::new(rate_limited.clone()))
+            .expect("unique metric");
+        registry
+            .register(Box::new(concurrency_limit.clone()))
+            .expect("unique metric");
+
+        Metrics {
+            registry,
+            requests,
+            latency,
+            shed,
+            rate_limited,
+            concurrency_limit,
+        }
+    })
+}
+
+/// Records one completed RPC.
+///
+/// Called from the service methods rather than from a middleware layer, because
+/// that is where the gRPC `Status` actually exists. In a layer the status lives
+/// in the response trailers, and reading it there means buffering the body to
+/// learn something the handler already knew.
+pub fn record_request(method: &str, status: &str, seconds: f64) {
+    let metrics = metrics();
+    metrics.requests.with_label_values(&[method, status]).inc();
+    metrics
+        .latency
+        .with_label_values(&[method])
+        .observe(seconds);
+}
+
+/// Records a request refused by the concurrency limiter.
+pub fn record_shed() {
+    metrics().shed.inc();
+}
+
+/// Records a request refused by the rate limiter.
+pub fn record_rate_limited() {
+    metrics().rate_limited.inc();
+}
+
+/// Publishes the current adaptive limit.
+pub fn set_concurrency_limit(limit: usize) {
+    metrics().concurrency_limit.set(limit as i64);
+}
+
+/// Renders the registry in Prometheus text exposition format.
+pub fn render() -> String {
+    let encoder = TextEncoder::new();
+    let mut buffer = Vec::new();
+    // An encoding failure here is a bug in a metric definition, not a runtime
+    // condition. Returning the error to a scraper would hide it; an empty body
+    // would look like a healthy server with no traffic.
+    encoder
+        .encode(&metrics().registry.gather(), &mut buffer)
+        .expect("metrics encode");
+    String::from_utf8(buffer).expect("metrics are utf-8")
+}
+
+/// Serves `/metrics` on its own port.
+///
+/// Separate from the gRPC listener on purpose. Metrics must stay scrapeable
+/// exactly when the main port is saturated, and sharing a listener would put
+/// them behind the same limiter that is shedding.
+pub async fn serve(addr: SocketAddr) -> std::io::Result<()> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind(addr).await?;
+
+    loop {
+        let (mut socket, _) = match listener.accept().await {
+            Ok(accepted) => accepted,
+            // One failed accept, typically a file descriptor limit, must not
+            // take the metrics endpoint down for good.
+            Err(_) => continue,
+        };
+
+        tokio::spawn(async move {
+            // Enough for a request line and headers. The endpoint answers the
+            // same way regardless of what was asked, so the request is read
+            // only to keep the client from seeing a reset before it finishes
+            // writing.
+            let mut discard = [0u8; 1024];
+            let _ = socket.read(&mut discard).await;
+
+            let body = render();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: text/plain; version=0.0.4\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+            let _ = socket.shutdown().await;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latency_buckets_are_sorted_and_cover_the_working_range() {
+        assert!(
+            LATENCY_BUCKETS.windows(2).all(|pair| pair[0] < pair[1]),
+            "prometheus requires strictly increasing bucket edges"
+        );
+
+        // The measured per-tag range, 363µs to 2,104µs, must not land in the
+        // first or last bucket, or every quantile inside it is interpolation
+        // across the whole range.
+        let light = 0.000_363;
+        let heavy = 0.002_104;
+        assert!(
+            LATENCY_BUCKETS[0] < light,
+            "light tags need buckets below them"
+        );
+        assert!(
+            LATENCY_BUCKETS.last().unwrap() > &heavy,
+            "heavy tags need buckets above them"
+        );
+        assert!(
+            LATENCY_BUCKETS.iter().filter(|edge| **edge < heavy).count() >= 4,
+            "the working range needs enough edges for a meaningful p999"
+        );
+    }
+
+    #[test]
+    fn rendering_produces_prometheus_text() {
+        record_request("Validate", "ok", 0.001);
+        record_shed();
+        set_concurrency_limit(17);
+
+        let rendered = render();
+
+        assert!(rendered.contains("vastlint_grpc_requests_total"));
+        assert!(rendered.contains("vastlint_grpc_shed_total"));
+        assert!(rendered.contains("vastlint_grpc_concurrency_limit 17"));
+        // Labels have to survive, or per-method breakdown is unavailable
+        // exactly when it is needed.
+        assert!(rendered.contains("method=\"Validate\""));
+        assert!(rendered.contains("status=\"ok\""));
+    }
+
+    #[test]
+    fn the_registry_is_shared_across_calls() {
+        let before = metrics().shed.get();
+        record_shed();
+        assert_eq!(metrics().shed.get(), before + 1);
+    }
+}

--- a/crates/vastlint-grpc/src/metrics.rs
+++ b/crates/vastlint-grpc/src/metrics.rs
@@ -42,6 +42,8 @@ struct Metrics {
     latency: HistogramVec,
     shed: IntCounter,
     rate_limited: IntCounter,
+    events_published: IntCounter,
+    events_dropped: IntCounter,
     concurrency_limit: IntGauge,
 }
 
@@ -82,6 +84,18 @@ fn metrics() -> &'static Metrics {
         )
         .expect("valid metric definition");
 
+        let events_published = IntCounter::new(
+            "vastlint_grpc_events_published_total",
+            "Validation events encoded and handed to the results-stream sink",
+        )
+        .expect("valid metric definition");
+
+        let events_dropped = IntCounter::new(
+            "vastlint_grpc_events_dropped_total",
+            "Validation events discarded because the publish queue was full",
+        )
+        .expect("valid metric definition");
+
         let concurrency_limit = IntGauge::new(
             "vastlint_grpc_concurrency_limit",
             "Current adaptive concurrency limit",
@@ -95,6 +109,12 @@ fn metrics() -> &'static Metrics {
             .register(Box::new(rate_limited.clone()))
             .expect("unique metric");
         registry
+            .register(Box::new(events_published.clone()))
+            .expect("unique metric");
+        registry
+            .register(Box::new(events_dropped.clone()))
+            .expect("unique metric");
+        registry
             .register(Box::new(concurrency_limit.clone()))
             .expect("unique metric");
 
@@ -104,6 +124,8 @@ fn metrics() -> &'static Metrics {
             latency,
             shed,
             rate_limited,
+            events_published,
+            events_dropped,
             concurrency_limit,
         }
     })
@@ -132,6 +154,25 @@ pub fn record_shed() {
 /// Records a request refused by the rate limiter.
 pub fn record_rate_limited() {
     metrics().rate_limited.inc();
+}
+
+/// Records a validation event encoded and handed to the sink.
+///
+/// Counted even when the sink discards, because the number worth watching is
+/// how many events the server believes it produced. A gap between this and what
+/// a consumer receives is a delivery problem; a gap between this and the request
+/// count is a bug here.
+pub fn record_event_published() {
+    metrics().events_published.inc();
+}
+
+/// Records a validation event dropped because the publish queue was full.
+///
+/// Telemetry loss has to be visible. A results stream that silently skips
+/// events under load is worse than one that is switched off, because a consumer
+/// counting rejections would read the gap as a drop in rejections.
+pub fn record_event_dropped() {
+    metrics().events_dropped.inc();
 }
 
 /// Publishes the current adaptive limit.

--- a/crates/vastlint-grpc/src/provenance.rs
+++ b/crates/vastlint-grpc/src/provenance.rs
@@ -1,0 +1,106 @@
+//! What produced a verdict.
+//!
+//! A validation result is only reproducible if the ruleset behind it can be
+//! identified later, which is the same reason an entity hierarchy needs an
+//! as-of date: both are questions about the past being asked of a model that
+//! has since moved.
+//!
+//! Three identifiers, because one is not enough:
+//!
+//! - `catalog_version` names a release.
+//! - `catalog_digest` pins what that release actually carried.
+//! - `engine_version` covers the evaluator, since the same ruleset read by a
+//!   different parser can reach a different verdict.
+
+use std::sync::OnceLock;
+
+use sha2::{Digest, Sha256};
+use vastlint_core::all_rules;
+
+use crate::proto;
+
+static CATALOG_DIGEST: OnceLock<String> = OnceLock::new();
+
+/// Content hash of the rule catalog this binary carries, as `sha256:<hex>`.
+///
+/// Computed over the linked catalog at first call rather than over the rule
+/// source at build time. That distinction is the whole point: it identifies
+/// what this binary will actually enforce, so it still differs if rules were
+/// compiled out or if a catalog was edited between tagged releases.
+///
+/// Covers each rule's ID, default severity, and source. A change to any of
+/// those changes the verdict a caller can expect, so all three belong in the
+/// hash. Rule *messages* are excluded deliberately: reworded prose does not
+/// change what passes or fails, and including it would churn the digest on
+/// every copy edit.
+pub fn catalog_digest() -> &'static str {
+    CATALOG_DIGEST.get_or_init(|| {
+        let mut hasher = Sha256::new();
+
+        for rule in all_rules() {
+            // Field separators, so that ("ab", "c") cannot hash the same as
+            // ("a", "bc").
+            hasher.update(rule.id.as_bytes());
+            hasher.update([0x1f]);
+            hasher.update(rule.default_severity.as_str().as_bytes());
+            hasher.update([0x1f]);
+            hasher.update(rule.source.as_str().as_bytes());
+            hasher.update([0x1e]);
+        }
+
+        format!("sha256:{:x}", hasher.finalize())
+    })
+}
+
+/// The provenance stamped onto every response.
+pub fn provenance() -> proto::Provenance {
+    proto::Provenance {
+        catalog_version: vastlint_core::VERSION.to_string(),
+        catalog_digest: catalog_digest().to_string(),
+        engine_version: vastlint_core::VERSION.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_is_stable_across_calls() {
+        assert_eq!(catalog_digest(), catalog_digest());
+    }
+
+    #[test]
+    fn digest_is_a_prefixed_sha256() {
+        let digest = catalog_digest();
+        let hex = digest.strip_prefix("sha256:").expect("sha256: prefix");
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn provenance_carries_the_engine_version() {
+        let provenance = provenance();
+        assert_eq!(provenance.engine_version, vastlint_core::VERSION);
+        assert!(!provenance.catalog_version.is_empty());
+    }
+
+    /// The digest must depend on the catalog contents, not just its length.
+    /// Recomputed here over a permuted catalog to prove the separators do their
+    /// job: without them, reordering or re-splitting fields could collide.
+    #[test]
+    fn field_separators_prevent_collisions() {
+        fn digest_of(pairs: &[(&str, &str)]) -> String {
+            let mut hasher = Sha256::new();
+            for (a, b) in pairs {
+                hasher.update(a.as_bytes());
+                hasher.update([0x1f]);
+                hasher.update(b.as_bytes());
+                hasher.update([0x1e]);
+            }
+            format!("{:x}", hasher.finalize())
+        }
+
+        assert_ne!(digest_of(&[("ab", "c")]), digest_of(&[("a", "bc")]));
+    }
+}

--- a/crates/vastlint-grpc/src/ratelimit.rs
+++ b/crates/vastlint-grpc/src/ratelimit.rs
@@ -1,0 +1,346 @@
+//! Per-caller rate limiting, as a token bucket.
+//!
+//! Distinct from the concurrency limiter, and both are needed. The concurrency
+//! limiter protects the server from the aggregate: it does not care who is
+//! calling, only that the box is full. The rate limiter protects callers from
+//! each other: one client in a retry storm can hold the concurrency limit shut
+//! for everyone else without ever exceeding it, because it refills the slot the
+//! instant it frees.
+//!
+//! ## What the caller identity is, and is not
+//!
+//! Identity comes from a request header. That is a fairness mechanism, not
+//! authentication: a caller can claim to be anyone. It is still useful, because
+//! the failure being prevented is an honest client misbehaving, not a
+//! determined attacker. Authenticating the identity is a separate piece of work
+//! and pretending a header does it would be worse than saying so.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use tonic::Status;
+use tower::{Layer, Service};
+
+use crate::config::RateLimitConfig;
+use crate::metrics;
+
+/// Identity used when a request carries no caller header.
+///
+/// All anonymous callers share one bucket. That is deliberate: giving each
+/// unidentified request its own allowance would make omitting the header the
+/// cheapest way to bypass the limit.
+const ANONYMOUS: &str = "anonymous";
+
+/// How long an idle bucket is kept before being reclaimed.
+///
+/// Without this the map grows once per distinct caller string, forever, which
+/// turns the rate limiter into a memory leak that a caller controls by varying
+/// a header.
+const BUCKET_TTL: Duration = Duration::from_secs(600);
+
+/// A single caller's allowance.
+#[derive(Debug)]
+struct Bucket {
+    /// Scaled by `SCALE` so refill can be fractional without floating point.
+    tokens: u64,
+    last_refill: Instant,
+    last_used: Instant,
+}
+
+/// Fixed-point scale for token accounting.
+///
+/// Integer tokens would round a 3 requests-per-second limit's refill to zero on
+/// any interval shorter than 333ms, so a caller polling every 100ms would never
+/// be refilled at all.
+const SCALE: u64 = 1_000_000;
+
+/// Token buckets, keyed by caller.
+#[derive(Debug)]
+pub struct RateLimiter {
+    config: RateLimitConfig,
+    buckets: Mutex<HashMap<String, Bucket>>,
+    /// Requests rejected, for metrics and for tests.
+    rejected: AtomicU64,
+}
+
+impl RateLimiter {
+    pub fn new(config: RateLimitConfig) -> Self {
+        Self {
+            config,
+            buckets: Mutex::new(HashMap::new()),
+            rejected: AtomicU64::new(0),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.config.per_second > 0
+    }
+
+    pub fn rejected(&self) -> u64 {
+        self.rejected.load(Ordering::Relaxed)
+    }
+
+    /// Takes one token for `caller`, or reports that the allowance is spent.
+    pub fn try_acquire(&self, caller: &str) -> bool {
+        self.try_acquire_at(caller, Instant::now())
+    }
+
+    /// Time is a parameter so the refill behaviour can be tested without
+    /// sleeping. A rate limiter tested by sleeping is a slow test suite and a
+    /// flaky one.
+    fn try_acquire_at(&self, caller: &str, now: Instant) -> bool {
+        if !self.enabled() {
+            return true;
+        }
+
+        let burst = self.config.burst.max(1) as u64 * SCALE;
+        let refill_per_second = self.config.per_second as u64 * SCALE;
+
+        let mut buckets = self.buckets.lock().unwrap_or_else(|poisoned| {
+            // A panic while holding the lock leaves the map intact: every
+            // operation on it is a single mutation. Refusing traffic because a
+            // previous request panicked would turn one bug into an outage.
+            poisoned.into_inner()
+        });
+
+        // Reclaim idle buckets while the lock is already held, rather than
+        // running a background task to do it.
+        if buckets.len() > 1_000 {
+            buckets.retain(|_, bucket| now.duration_since(bucket.last_used) < BUCKET_TTL);
+        }
+
+        let bucket = buckets.entry(caller.to_string()).or_insert(Bucket {
+            tokens: burst,
+            last_refill: now,
+            last_used: now,
+        });
+
+        let elapsed = now.saturating_duration_since(bucket.last_refill);
+        let refill = (elapsed.as_secs_f64() * refill_per_second as f64) as u64;
+        bucket.tokens = bucket.tokens.saturating_add(refill).min(burst);
+        bucket.last_refill = now;
+        bucket.last_used = now;
+
+        if bucket.tokens >= SCALE {
+            bucket.tokens -= SCALE;
+            true
+        } else {
+            self.rejected.fetch_add(1, Ordering::Relaxed);
+            false
+        }
+    }
+}
+
+/// Tower layer applying per-caller rate limits.
+#[derive(Debug, Clone)]
+pub struct RateLimitLayer {
+    limiter: Arc<RateLimiter>,
+    caller_header: Arc<str>,
+}
+
+impl RateLimitLayer {
+    pub fn new(limiter: Arc<RateLimiter>, caller_header: impl Into<Arc<str>>) -> Self {
+        Self {
+            limiter,
+            caller_header: caller_header.into(),
+        }
+    }
+}
+
+impl<S> Layer<S> for RateLimitLayer {
+    type Service = RateLimited<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RateLimited {
+            inner,
+            limiter: Arc::clone(&self.limiter),
+            caller_header: Arc::clone(&self.caller_header),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RateLimited<S> {
+    inner: S,
+    limiter: Arc<RateLimiter>,
+    caller_header: Arc<str>,
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for RateLimited<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: http::Request<ReqBody>) -> Self::Future {
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        if !self.limiter.enabled() {
+            return Box::pin(async move { inner.call(request).await });
+        }
+
+        let caller = request
+            .headers()
+            .get(self.caller_header.as_ref())
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+            .unwrap_or(ANONYMOUS);
+
+        if !self.limiter.try_acquire(caller) {
+            metrics::record_rate_limited();
+            // RESOURCE_EXHAUSTED, the same code as a concurrency shed. gRPC has
+            // no separate rate-limit status, and callers should treat both the
+            // same way: back off and retry later.
+            let response =
+                Status::resource_exhausted("per-caller rate limit exceeded; retry with backoff")
+                    .into_http();
+            return Box::pin(async move { Ok(response) });
+        }
+
+        Box::pin(async move { inner.call(request).await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limiter(per_second: u32, burst: u32) -> RateLimiter {
+        RateLimiter::new(RateLimitConfig { per_second, burst })
+    }
+
+    #[test]
+    fn a_disabled_limiter_allows_everything() {
+        let limiter = limiter(0, 0);
+        assert!(!limiter.enabled());
+        for _ in 0..10_000 {
+            assert!(limiter.try_acquire("someone"));
+        }
+        assert_eq!(limiter.rejected(), 0);
+    }
+
+    #[test]
+    fn a_caller_may_spend_its_burst_immediately() {
+        let limiter = limiter(10, 5);
+        let now = Instant::now();
+
+        for i in 0..5 {
+            assert!(limiter.try_acquire_at("a", now), "request {i} within burst");
+        }
+        assert!(!limiter.try_acquire_at("a", now), "burst is spent");
+    }
+
+    #[test]
+    fn tokens_refill_over_time() {
+        let limiter = limiter(10, 2);
+        let start = Instant::now();
+
+        assert!(limiter.try_acquire_at("a", start));
+        assert!(limiter.try_acquire_at("a", start));
+        assert!(!limiter.try_acquire_at("a", start));
+
+        // 10 per second means one token every 100ms.
+        assert!(limiter.try_acquire_at("a", start + Duration::from_millis(100)));
+    }
+
+    /// Integer token accounting would round this refill to zero and starve the
+    /// caller permanently.
+    #[test]
+    fn slow_rates_still_refill_on_short_intervals() {
+        let limiter = limiter(3, 1);
+        let start = Instant::now();
+
+        assert!(limiter.try_acquire_at("a", start));
+        assert!(!limiter.try_acquire_at("a", start));
+
+        // Four 100ms steps at 3/s is 1.2 tokens, so the fifth call succeeds
+        // even though no single step earns a whole token.
+        let mut allowed = false;
+        for step in 1..=4 {
+            allowed |= limiter.try_acquire_at("a", start + Duration::from_millis(100 * step));
+        }
+        assert!(allowed, "fractional refill must accumulate");
+    }
+
+    #[test]
+    fn the_bucket_never_exceeds_its_burst() {
+        let limiter = limiter(100, 3);
+        let start = Instant::now();
+
+        // An hour of idling must not bank an hour of tokens.
+        let much_later = start + Duration::from_secs(3600);
+        for i in 0..3 {
+            assert!(limiter.try_acquire_at("a", much_later), "banked token {i}");
+        }
+        assert!(!limiter.try_acquire_at("a", much_later), "burst is the cap");
+    }
+
+    #[test]
+    fn callers_do_not_share_an_allowance() {
+        let limiter = limiter(10, 2);
+        let now = Instant::now();
+
+        assert!(limiter.try_acquire_at("noisy", now));
+        assert!(limiter.try_acquire_at("noisy", now));
+        assert!(!limiter.try_acquire_at("noisy", now), "noisy is spent");
+
+        assert!(
+            limiter.try_acquire_at("quiet", now),
+            "one caller must not spend another's allowance"
+        );
+    }
+
+    #[test]
+    fn rejections_are_counted() {
+        let limiter = limiter(1, 1);
+        let now = Instant::now();
+
+        assert!(limiter.try_acquire_at("a", now));
+        assert!(!limiter.try_acquire_at("a", now));
+        assert!(!limiter.try_acquire_at("a", now));
+
+        assert_eq!(limiter.rejected(), 2);
+    }
+
+    /// A zero burst would reject every request forever, including the first.
+    #[test]
+    fn a_zero_burst_is_treated_as_one() {
+        let limiter = limiter(5, 0);
+        assert!(limiter.try_acquire_at("a", Instant::now()));
+    }
+
+    #[test]
+    fn idle_buckets_are_reclaimed() {
+        let limiter = limiter(10, 10);
+        let start = Instant::now();
+
+        for i in 0..1_100 {
+            limiter.try_acquire_at(&format!("caller-{i}"), start);
+        }
+        assert!(limiter.buckets.lock().unwrap().len() > 1_000);
+
+        // One more request, long after the rest went idle.
+        limiter.try_acquire_at("late", start + BUCKET_TTL + Duration::from_secs(1));
+
+        let remaining = limiter.buckets.lock().unwrap().len();
+        assert!(
+            remaining < 10,
+            "expired buckets should be reclaimed, {remaining} remain"
+        );
+    }
+}

--- a/crates/vastlint-grpc/src/service.rs
+++ b/crates/vastlint-grpc/src/service.rs
@@ -16,6 +16,7 @@ use vastlint_core as core;
 
 use crate::convert;
 use crate::deadline;
+use crate::events::{Publisher, ValidationEvent};
 use crate::limit::AdaptiveLimiter;
 use crate::metrics;
 use crate::proto::vastlint_service_server::VastlintService;
@@ -40,6 +41,10 @@ pub struct VastlintApi {
     /// running with the limiter disabled gets.
     limiter: Option<Arc<AdaptiveLimiter>>,
     stream_buffer: usize,
+    /// Results stream. `None` means no events are produced at all, which is the
+    /// default and what every test uses.
+    publisher: Option<Arc<Publisher>>,
+    schema_id: u32,
 }
 
 impl VastlintApi {
@@ -47,7 +52,33 @@ impl VastlintApi {
         Self {
             limiter: None,
             stream_buffer: DEFAULT_STREAM_BUFFER,
+            publisher: None,
+            schema_id: 0,
         }
+    }
+
+    /// Attaches the results stream.
+    ///
+    /// Publishing is best effort and never on the critical path: an event that
+    /// cannot be queued is dropped and counted rather than awaited.
+    pub fn with_publisher(mut self, publisher: Arc<Publisher>, schema_id: u32) -> Self {
+        self.publisher = Some(publisher);
+        self.schema_id = schema_id;
+        self
+    }
+
+    /// Publishes one verdict, if a stream is configured.
+    fn emit(&self, event_id: String, result: &core::ValidationResult, caller: Option<String>) {
+        let Some(publisher) = &self.publisher else {
+            return;
+        };
+
+        let version = result
+            .version
+            .best()
+            .map(|version| version.as_str().to_string());
+        let event = ValidationEvent::from_result(event_id, result, version, caller);
+        publisher.publish(&event, self.schema_id);
     }
 
     /// Sets the in-flight bound for streams without attaching a limiter.
@@ -143,6 +174,42 @@ where
     result
 }
 
+/// Monotonic counter behind event ids.
+///
+/// Not a UUID. An event id has to be unique within this process's output and
+/// traceable back to a log line; a counter with the process start time folded
+/// in gives both without a dependency, and consumers deduplicate on the whole
+/// string rather than parsing it.
+fn next_event_id() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    static EPOCH: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+
+    let epoch = *EPOCH.get_or_init(|| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|since| since.as_secs())
+            .unwrap_or(0)
+    });
+
+    epoch
+        .wrapping_shl(24)
+        .wrapping_add(COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+/// Caller identity from request metadata, for event attribution.
+///
+/// Self-asserted, like the rate limiter's view of it. Fine for attributing a
+/// stream of rejections back to whoever submitted them, not fine for anything
+/// that needs to be true.
+fn caller_identity(metadata: &tonic::metadata::MetadataMap) -> Option<String> {
+    metadata
+        .get("x-vastlint-caller")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
 /// Stable label for a gRPC status code.
 ///
 /// Written out rather than derived from `Debug`, because a metric label is a
@@ -170,6 +237,8 @@ impl VastlintService for VastlintApi {
     ) -> Result<Response<ValidateResponse>, Status> {
         observed("Validate", async move {
             let budget = deadline::remaining(request.metadata());
+            let caller = caller_identity(request.metadata());
+            let event_id = format!("{:016x}", next_event_id());
             let request = request.into_inner();
             let (context, forced) = convert::validation_context(request.context)?;
             let document = request.document;
@@ -178,6 +247,8 @@ impl VastlintService for VastlintApi {
                 core::validate_with_context(&document, context)
             })
             .await?;
+
+            self.emit(event_id, &result, caller);
 
             Ok(Response::new(ValidateResponse {
                 verdict: Some(convert::verdict(&result, forced)),

--- a/crates/vastlint-grpc/src/service.rs
+++ b/crates/vastlint-grpc/src/service.rs
@@ -5,14 +5,15 @@
 //! decision is made here.
 
 use std::pin::Pin;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::time::timeout;
-use tonic::{Request, Response, Status, Streaming};
+use tonic::{Code, Request, Response, Status, Streaming};
 use vastlint_core as core;
 
 use crate::convert;
 use crate::deadline;
+use crate::metrics;
 use crate::proto::vastlint_service_server::VastlintService;
 use crate::proto::{
     FixRequest, FixResponse, ListRulesRequest, ListRulesResponse, RuleSource, ValidateRequest,
@@ -81,25 +82,69 @@ where
     })
 }
 
+/// Times one RPC and records its outcome.
+///
+/// Instrumentation lives here rather than in a middleware layer because this is
+/// where the gRPC `Status` exists. In a layer the status is in the response
+/// trailers, so labelling by status code would mean buffering the body to
+/// recover something the handler already had in hand.
+async fn observed<T, F>(method: &'static str, work: F) -> Result<Response<T>, Status>
+where
+    F: std::future::Future<Output = Result<Response<T>, Status>>,
+{
+    let started = Instant::now();
+    let result = work.await;
+
+    let status = match &result {
+        Ok(_) => "ok",
+        Err(status) => status_label(status.code()),
+    };
+    metrics::record_request(method, status, started.elapsed().as_secs_f64());
+
+    result
+}
+
+/// Stable label for a gRPC status code.
+///
+/// Written out rather than derived from `Debug`, because a metric label is a
+/// contract with whatever dashboard consumes it: a formatting change upstream
+/// must not silently rename a time series and orphan the panel built on it.
+fn status_label(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "ok",
+        Code::InvalidArgument => "invalid_argument",
+        Code::DeadlineExceeded => "deadline_exceeded",
+        Code::ResourceExhausted => "resource_exhausted",
+        Code::Unimplemented => "unimplemented",
+        Code::Internal => "internal",
+        Code::Unavailable => "unavailable",
+        Code::Cancelled => "cancelled",
+        _ => "other",
+    }
+}
+
 #[tonic::async_trait]
 impl VastlintService for VastlintApi {
     async fn validate(
         &self,
         request: Request<ValidateRequest>,
     ) -> Result<Response<ValidateResponse>, Status> {
-        let budget = deadline::remaining(request.metadata());
-        let request = request.into_inner();
-        let (context, forced) = convert::validation_context(request.context)?;
-        let document = request.document;
+        observed("Validate", async move {
+            let budget = deadline::remaining(request.metadata());
+            let request = request.into_inner();
+            let (context, forced) = convert::validation_context(request.context)?;
+            let document = request.document;
 
-        let result = run(budget, move || {
-            core::validate_with_context(&document, context)
+            let result = run(budget, move || {
+                core::validate_with_context(&document, context)
+            })
+            .await?;
+
+            Ok(Response::new(ValidateResponse {
+                verdict: Some(convert::verdict(&result, forced)),
+            }))
         })
-        .await?;
-
-        Ok(Response::new(ValidateResponse {
-            verdict: Some(convert::verdict(&result, forced)),
-        }))
+        .await
     }
 
     type ValidateStreamStream =
@@ -123,22 +168,34 @@ impl VastlintService for VastlintApi {
     }
 
     async fn fix(&self, request: Request<FixRequest>) -> Result<Response<FixResponse>, Status> {
-        let budget = deadline::remaining(request.metadata());
-        let request = request.into_inner();
-        let (context, _) = convert::validation_context(request.context)?;
-        let document = request.document;
+        observed("Fix", async move {
+            let budget = deadline::remaining(request.metadata());
+            let request = request.into_inner();
+            let (context, _) = convert::validation_context(request.context)?;
+            let document = request.document;
 
-        let result = run(budget, move || core::fix_with_context(&document, context)).await?;
+            let result = run(budget, move || core::fix_with_context(&document, context)).await?;
 
-        Ok(Response::new(FixResponse {
-            document: result.xml,
-            applied: result.applied.iter().map(convert::applied_fix).collect(),
-            remaining: result.remaining.iter().map(convert::issue).collect(),
-            provenance: Some(provenance()),
-        }))
+            Ok(Response::new(FixResponse {
+                document: result.xml,
+                applied: result.applied.iter().map(convert::applied_fix).collect(),
+                remaining: result.remaining.iter().map(convert::issue).collect(),
+                provenance: Some(provenance()),
+            }))
+        })
+        .await
     }
 
     async fn list_rules(
+        &self,
+        request: Request<ListRulesRequest>,
+    ) -> Result<Response<ListRulesResponse>, Status> {
+        observed("ListRules", async move { self.list_rules_inner(request) }).await
+    }
+}
+
+impl VastlintApi {
+    fn list_rules_inner(
         &self,
         request: Request<ListRulesRequest>,
     ) -> Result<Response<ListRulesResponse>, Status> {

--- a/crates/vastlint-grpc/src/service.rs
+++ b/crates/vastlint-grpc/src/service.rs
@@ -1,0 +1,366 @@
+//! The `openadtech.vastlint.v1` service implementation.
+//!
+//! Every RPC follows the same shape: translate the request, hand the work to
+//! `vastlint-core` on a blocking thread, translate the result. No validation
+//! decision is made here.
+
+use std::pin::Pin;
+use std::time::Duration;
+
+use tokio::time::timeout;
+use tonic::{Request, Response, Status, Streaming};
+use vastlint_core as core;
+
+use crate::convert;
+use crate::deadline;
+use crate::proto::vastlint_service_server::VastlintService;
+use crate::proto::{
+    FixRequest, FixResponse, ListRulesRequest, ListRulesResponse, RuleSource, ValidateRequest,
+    ValidateResponse, ValidateStreamRequest, ValidateStreamResponse,
+};
+use crate::provenance::provenance;
+
+/// The service. Stateless: the rule catalog is static and validation carries no
+/// session, so one instance serves every connection and cloning is free.
+#[derive(Debug, Clone, Default)]
+pub struct VastlintApi;
+
+impl VastlintApi {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Runs CPU-bound validation work without blocking the runtime, and gives up on
+/// it when the caller's deadline passes.
+///
+/// One honest limitation: `spawn_blocking` tasks cannot be cancelled. When the
+/// deadline fires, the caller gets `DEADLINE_EXCEEDED` immediately but the
+/// worker thread runs to completion. For vastlint that is bounded and short,
+/// 363µs light and 2,104µs heavy per tag, so the wasted work is small. It is
+/// still real, and it is the reason phase 3 needs a concurrency limit rather
+/// than relying on deadlines alone to protect capacity: a deadline stops the
+/// waiting, not the working.
+async fn run<T, F>(deadline: Option<Duration>, work: F) -> Result<T, Status>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    // Nothing left to spend. Refusing before starting is the point: work that
+    // completes after its deadline has consumed capacity for a caller that has
+    // already stopped listening.
+    if deadline == Some(Duration::ZERO) {
+        return Err(Status::deadline_exceeded(
+            "deadline had already expired when the request arrived",
+        ));
+    }
+
+    let handle = tokio::task::spawn_blocking(work);
+
+    let joined = match deadline {
+        Some(budget) => match timeout(budget, handle).await {
+            Ok(joined) => joined,
+            Err(_) => {
+                return Err(Status::deadline_exceeded(
+                    "validation did not complete within the caller's deadline",
+                ))
+            }
+        },
+        None => handle.await,
+    };
+
+    joined.map_err(|err| {
+        // A panic in the core is a bug, not a client error. Report it as
+        // internal and say nothing about its contents: panic messages have a
+        // habit of carrying document fragments.
+        Status::internal(if err.is_panic() {
+            "validation worker panicked"
+        } else {
+            "validation worker was cancelled"
+        })
+    })
+}
+
+#[tonic::async_trait]
+impl VastlintService for VastlintApi {
+    async fn validate(
+        &self,
+        request: Request<ValidateRequest>,
+    ) -> Result<Response<ValidateResponse>, Status> {
+        let budget = deadline::remaining(request.metadata());
+        let request = request.into_inner();
+        let (context, forced) = convert::validation_context(request.context)?;
+        let document = request.document;
+
+        let result = run(budget, move || {
+            core::validate_with_context(&document, context)
+        })
+        .await?;
+
+        Ok(Response::new(ValidateResponse {
+            verdict: Some(convert::verdict(&result, forced)),
+        }))
+    }
+
+    type ValidateStreamStream =
+        Pin<Box<dyn tokio_stream::Stream<Item = Result<ValidateStreamResponse, Status>> + Send>>;
+
+    /// Not implemented yet.
+    ///
+    /// Deliberately absent rather than naively present. A streaming
+    /// implementation that reads as fast as the client writes has an unbounded
+    /// buffer, which is worse than no streaming at all: it converts a fast
+    /// producer into server memory exhaustion. The bounded channel it needs
+    /// belongs with the concurrency limiter, so both arrive together.
+    async fn validate_stream(
+        &self,
+        _request: Request<Streaming<ValidateStreamRequest>>,
+    ) -> Result<Response<Self::ValidateStreamStream>, Status> {
+        Err(Status::unimplemented(
+            "ValidateStream is not implemented yet; use Validate. \
+             Streaming lands with the bounded worker channel and the concurrency limiter",
+        ))
+    }
+
+    async fn fix(&self, request: Request<FixRequest>) -> Result<Response<FixResponse>, Status> {
+        let budget = deadline::remaining(request.metadata());
+        let request = request.into_inner();
+        let (context, _) = convert::validation_context(request.context)?;
+        let document = request.document;
+
+        let result = run(budget, move || core::fix_with_context(&document, context)).await?;
+
+        Ok(Response::new(FixResponse {
+            document: result.xml,
+            applied: result.applied.iter().map(convert::applied_fix).collect(),
+            remaining: result.remaining.iter().map(convert::issue).collect(),
+            provenance: Some(provenance()),
+        }))
+    }
+
+    async fn list_rules(
+        &self,
+        request: Request<ListRulesRequest>,
+    ) -> Result<Response<ListRulesResponse>, Status> {
+        let request = request.into_inner();
+
+        // An unrecognised source is a client error rather than a filter that
+        // matches nothing, on the same reasoning as unknown rule IDs: silently
+        // returning an empty catalog looks like a catalog with no rules.
+        let mut wanted = Vec::with_capacity(request.sources.len());
+        for raw in &request.sources {
+            let source = RuleSource::try_from(*raw)
+                .map_err(|_| Status::invalid_argument(format!("unrecognised rule source {raw}")))?;
+
+            if source == RuleSource::Unspecified {
+                return Err(Status::invalid_argument(
+                    "RULE_SOURCE_UNSPECIFIED is not a filter; omit sources to list every rule",
+                ));
+            }
+
+            wanted.push(source);
+        }
+
+        let rules = core::all_rules()
+            .iter()
+            .filter(|rule| wanted.is_empty() || wanted.contains(&convert::rule_source(rule.source)))
+            .map(convert::rule_meta)
+            .collect();
+
+        Ok(Response::new(ListRulesResponse {
+            rules,
+            provenance: Some(provenance()),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::{Severity, ValidationContext};
+
+    /// A tag with an obvious defect: no Impression, which the spec requires.
+    const INVALID_VAST: &str = r#"<VAST version="4.1"><Ad id="1"><InLine></InLine></Ad></VAST>"#;
+
+    fn service() -> VastlintApi {
+        VastlintApi::new()
+    }
+
+    #[tokio::test]
+    async fn validate_reports_findings_with_provenance() {
+        let response = service()
+            .validate(Request::new(ValidateRequest {
+                document: INVALID_VAST.to_string(),
+                context: None,
+            }))
+            .await
+            .expect("validate succeeds")
+            .into_inner();
+
+        let verdict = response.verdict.expect("verdict present");
+        assert!(!verdict.valid, "a tag with no Impression is not valid");
+        assert!(!verdict.issues.is_empty());
+
+        let provenance = verdict.provenance.expect("provenance present");
+        assert!(provenance.catalog_digest.starts_with("sha256:"));
+        assert_eq!(provenance.engine_version, core::VERSION);
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_unknown_rule_overrides() {
+        let status = service()
+            .validate(Request::new(ValidateRequest {
+                document: INVALID_VAST.to_string(),
+                context: Some(ValidationContext {
+                    rule_overrides: [("not-a-rule".to_string(), 4)].into_iter().collect(),
+                    ..Default::default()
+                }),
+            }))
+            .await
+            .expect_err("unknown rule id is rejected");
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    }
+
+    /// The override has to actually reach the core, not just be accepted.
+    #[tokio::test]
+    async fn silencing_a_rule_removes_its_finding() {
+        let before = service()
+            .validate(Request::new(ValidateRequest {
+                document: INVALID_VAST.to_string(),
+                context: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .verdict
+            .unwrap();
+
+        let silenced = before
+            .issues
+            .first()
+            .expect("at least one finding")
+            .rule_id
+            .clone();
+
+        let after = service()
+            .validate(Request::new(ValidateRequest {
+                document: INVALID_VAST.to_string(),
+                context: Some(ValidationContext {
+                    // 4 is RULE_LEVEL_OFF.
+                    rule_overrides: [(silenced.clone(), 4)].into_iter().collect(),
+                    ..Default::default()
+                }),
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .verdict
+            .unwrap();
+
+        assert!(
+            !after.issues.iter().any(|issue| issue.rule_id == silenced),
+            "rule {silenced} should have been silenced"
+        );
+    }
+
+    #[tokio::test]
+    async fn fix_returns_a_repaired_document() {
+        let insecure = r#"<VAST version="4.1"><Ad id="1"><InLine><AdSystem>x</AdSystem><AdTitle>x</AdTitle><Impression>http://track.example.com/i</Impression></InLine></Ad></VAST>"#;
+
+        let response = service()
+            .fix(Request::new(FixRequest {
+                document: insecure.to_string(),
+                context: None,
+            }))
+            .await
+            .expect("fix succeeds")
+            .into_inner();
+
+        assert!(!response.document.is_empty());
+        assert!(response.provenance.is_some());
+    }
+
+    #[tokio::test]
+    async fn list_rules_returns_the_whole_catalog_by_default() {
+        let response = service()
+            .list_rules(Request::new(ListRulesRequest::default()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.rules.len(), core::all_rules().len());
+        assert!(response.rules.iter().all(|rule| !rule.rule_id.is_empty()));
+        assert!(response
+            .rules
+            .iter()
+            .all(|rule| rule.default_severity != Severity::Unspecified as i32));
+    }
+
+    #[tokio::test]
+    async fn list_rules_filters_by_source() {
+        let response = service()
+            .list_rules(Request::new(ListRulesRequest {
+                sources: vec![RuleSource::Rfc3986 as i32],
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(!response.rules.is_empty(), "the catalog has RFC 3986 rules");
+        assert!(response
+            .rules
+            .iter()
+            .all(|rule| rule.source == RuleSource::Rfc3986 as i32));
+        assert!(response.rules.len() < core::all_rules().len());
+    }
+
+    #[tokio::test]
+    async fn list_rules_rejects_the_unspecified_source_as_a_filter() {
+        let status = service()
+            .list_rules(Request::new(ListRulesRequest {
+                sources: vec![RuleSource::Unspecified as i32],
+            }))
+            .await
+            .expect_err("unspecified is not a filter");
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn an_expired_deadline_is_refused_before_any_work_starts() {
+        let mut request = Request::new(ValidateRequest {
+            document: INVALID_VAST.to_string(),
+            context: None,
+        });
+        request
+            .metadata_mut()
+            .insert("grpc-timeout", "0m".parse().unwrap());
+
+        let status = service()
+            .validate(request)
+            .await
+            .expect_err("an expired deadline is refused");
+
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+    }
+
+    #[tokio::test]
+    async fn a_generous_deadline_is_honoured() {
+        let mut request = Request::new(ValidateRequest {
+            document: INVALID_VAST.to_string(),
+            context: None,
+        });
+        request
+            .metadata_mut()
+            .insert("grpc-timeout", "30S".parse().unwrap());
+
+        let response = service().validate(request).await;
+        assert!(response.is_ok(), "30 seconds is ample for one small tag");
+    }
+
+    // ValidateStream's UNIMPLEMENTED status is covered in tests/server.rs, over
+    // a real client: constructing a `Streaming` by hand outside the transport
+    // is not something callers can do, so testing it here would test a shape
+    // that never occurs.
+}

--- a/crates/vastlint-grpc/src/service.rs
+++ b/crates/vastlint-grpc/src/service.rs
@@ -5,30 +5,69 @@
 //! decision is made here.
 
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use tokio::sync::mpsc;
 use tokio::time::timeout;
+use tokio_stream::StreamExt;
 use tonic::{Code, Request, Response, Status, Streaming};
 use vastlint_core as core;
 
 use crate::convert;
 use crate::deadline;
+use crate::limit::AdaptiveLimiter;
 use crate::metrics;
 use crate::proto::vastlint_service_server::VastlintService;
 use crate::proto::{
-    FixRequest, FixResponse, ListRulesRequest, ListRulesResponse, RuleSource, ValidateRequest,
-    ValidateResponse, ValidateStreamRequest, ValidateStreamResponse,
+    FixRequest, FixResponse, ListRulesRequest, ListRulesResponse, RuleSource, StreamError,
+    ValidateRequest, ValidateResponse, ValidateStreamRequest, ValidateStreamResponse,
 };
 use crate::provenance::provenance;
 
-/// The service. Stateless: the rule catalog is static and validation carries no
-/// session, so one instance serves every connection and cloning is free.
+/// Default in-flight bound for a stream when none is configured.
+const DEFAULT_STREAM_BUFFER: usize = 32;
+
+/// The service.
+///
+/// Stateless apart from the limiter, which is shared: the rule catalog is
+/// static and validation carries no session, so one instance serves every
+/// connection.
 #[derive(Debug, Clone, Default)]
-pub struct VastlintApi;
+pub struct VastlintApi {
+    /// Used for per-message admission on streams. `None` means streaming admits
+    /// everything, which is what the unit tests want and what a deployment
+    /// running with the limiter disabled gets.
+    limiter: Option<Arc<AdaptiveLimiter>>,
+    stream_buffer: usize,
+}
 
 impl VastlintApi {
     pub fn new() -> Self {
-        Self
+        Self {
+            limiter: None,
+            stream_buffer: DEFAULT_STREAM_BUFFER,
+        }
+    }
+
+    /// Sets the in-flight bound for streams without attaching a limiter.
+    ///
+    /// Separate from [`Self::with_limiter`] so a test can exercise the buffer
+    /// bound on its own, without admission control also being in play.
+    pub fn with_stream_buffer(mut self, stream_buffer: usize) -> Self {
+        self.stream_buffer = stream_buffer.max(1);
+        self
+    }
+
+    /// Shares the server's concurrency limiter with the streaming handler.
+    ///
+    /// Streams are exempt from the tower layer that governs unary calls, so
+    /// without this a stream would be the one path into the validator with no
+    /// admission control at all.
+    pub fn with_limiter(mut self, limiter: Arc<AdaptiveLimiter>, stream_buffer: usize) -> Self {
+        self.limiter = Some(limiter);
+        self.stream_buffer = stream_buffer.max(1);
+        self
     }
 }
 
@@ -150,21 +189,156 @@ impl VastlintService for VastlintApi {
     type ValidateStreamStream =
         Pin<Box<dyn tokio_stream::Stream<Item = Result<ValidateStreamResponse, Status>> + Send>>;
 
-    /// Not implemented yet.
+    /// Bulk validation over a bidirectional stream.
     ///
-    /// Deliberately absent rather than naively present. A streaming
-    /// implementation that reads as fast as the client writes has an unbounded
-    /// buffer, which is worse than no streaming at all: it converts a fast
-    /// producer into server memory exhaustion. The bounded channel it needs
-    /// belongs with the concurrency limiter, so both arrive together.
+    /// ## Backpressure
+    ///
+    /// The outbound channel is bounded, and a slot on it is reserved *before*
+    /// the next inbound message is read. When the buffer is full the handler
+    /// stops reading, which stalls the HTTP/2 receive window and blocks the
+    /// client's writes. That is what makes the backpressure real rather than
+    /// decorative: the alternative, reading as fast as the client can write,
+    /// has an unbounded buffer and converts a fast producer into server memory
+    /// exhaustion while reporting excellent throughput right up to the moment
+    /// it dies.
+    ///
+    /// ## Ordering
+    ///
+    /// Responses are not ordered. Messages are dispatched concurrently and a
+    /// light document behind a heavy one will finish first, which is the point
+    /// of streaming. Callers correlate on `request_id`, which the contract
+    /// requires for exactly this reason.
+    ///
+    /// ## Admission
+    ///
+    /// Per message, not per stream. See `limit::UNGOVERNED_PATHS` for why the
+    /// tower layer must not govern this call. A shed message becomes a
+    /// `StreamError` on its own `request_id` and the stream continues: one
+    /// document being refused is not a reason to tear down a connection that is
+    /// successfully validating everything else.
     async fn validate_stream(
         &self,
-        _request: Request<Streaming<ValidateStreamRequest>>,
+        request: Request<Streaming<ValidateStreamRequest>>,
     ) -> Result<Response<Self::ValidateStreamStream>, Status> {
-        Err(Status::unimplemented(
-            "ValidateStream is not implemented yet; use Validate. \
-             Streaming lands with the bounded worker channel and the concurrency limiter",
-        ))
+        let budget = deadline::remaining(request.metadata());
+        let mut inbound = request.into_inner();
+
+        let (tx, rx) = mpsc::channel::<Result<ValidateStreamResponse, Status>>(self.stream_buffer);
+        let limiter = self.limiter.clone();
+
+        tokio::spawn(async move {
+            while let Some(message) = inbound.next().await {
+                let message = match message {
+                    Ok(message) => message,
+                    // The client hung up or sent something undecodable. Report
+                    // it once on the call and stop; there is no request_id to
+                    // attribute it to.
+                    Err(status) => {
+                        let _ = tx.send(Err(status)).await;
+                        return;
+                    }
+                };
+
+                // Reserving before doing any work is what applies the
+                // backpressure. `reserve_owned` waits for a free slot, so a slow
+                // reader stops this loop rather than growing a queue behind it.
+                let Ok(permit) = tx.clone().reserve_owned().await else {
+                    // Receiver dropped: the client is gone and every remaining
+                    // message is work nobody will read.
+                    return;
+                };
+
+                let request_id = message.request_id;
+
+                let context = match convert::validation_context(message.context) {
+                    Ok(context) => context,
+                    Err(status) => {
+                        permit.send(Ok(ValidateStreamResponse {
+                            request_id,
+                            verdict: None,
+                            error: Some(StreamError {
+                                code: status.code() as i32,
+                                message: status.message().to_string(),
+                            }),
+                        }));
+                        continue;
+                    }
+                };
+
+                let admitted = match &limiter {
+                    Some(limiter) => match limiter.try_admit() {
+                        Some(admitted) => Some(admitted),
+                        None => {
+                            metrics::record_shed();
+                            permit.send(Ok(ValidateStreamResponse {
+                                request_id,
+                                verdict: None,
+                                error: Some(StreamError {
+                                    code: Code::ResourceExhausted as i32,
+                                    message: "server is at its concurrency limit; \
+                                              retry this document with backoff"
+                                        .to_string(),
+                                }),
+                            }));
+                            continue;
+                        }
+                    },
+                    None => None,
+                };
+
+                let (context, forced) = context;
+                let document = message.document;
+
+                tokio::spawn(async move {
+                    let started = Instant::now();
+                    let outcome = run(budget, move || {
+                        core::validate_with_context(&document, context)
+                    })
+                    .await;
+
+                    // Held until the work is done so the latency sample covers
+                    // the validation, then dropped before the send so a slow
+                    // reader does not count against the concurrency limit.
+                    drop(admitted);
+
+                    let response = match outcome {
+                        Ok(result) => {
+                            metrics::record_request(
+                                "ValidateStream",
+                                "ok",
+                                started.elapsed().as_secs_f64(),
+                            );
+                            ValidateStreamResponse {
+                                request_id,
+                                verdict: Some(convert::verdict(&result, forced)),
+                                error: None,
+                            }
+                        }
+                        Err(status) => {
+                            metrics::record_request(
+                                "ValidateStream",
+                                status_label(status.code()),
+                                started.elapsed().as_secs_f64(),
+                            );
+                            ValidateStreamResponse {
+                                request_id,
+                                verdict: None,
+                                error: Some(StreamError {
+                                    code: status.code() as i32,
+                                    message: status.message().to_string(),
+                                }),
+                            }
+                        }
+                    };
+
+                    permit.send(Ok(response));
+                });
+            }
+        });
+
+        Ok(Response::new(Box::pin(
+            tokio_stream::wrappers::ReceiverStream::new(rx),
+        )))
     }
 
     async fn fix(&self, request: Request<FixRequest>) -> Result<Response<FixResponse>, Status> {

--- a/crates/vastlint-grpc/tests/backpressure.rs
+++ b/crates/vastlint-grpc/tests/backpressure.rs
@@ -107,25 +107,36 @@ async fn a_client_that_does_not_read_stalls_the_server() {
 
     // Everything has been handed to the transport and nothing has been read
     // back. A server with no bound anywhere would work through all of it.
-    tokio::time::sleep(Duration::from_millis(400)).await;
-    let first = completed();
-
-    tokio::time::sleep(Duration::from_millis(400)).await;
-    let second = completed();
+    //
+    // Polled until two consecutive samples match rather than compared at two
+    // fixed instants. A fixed comparison assumes the plateau is reached within
+    // some wall-clock time, which is true on a quiet laptop and not necessarily
+    // true on a shared CI runner. Waiting for the plateau tests the property
+    // instead of the machine.
+    let mut previous = u64::MAX;
+    let mut stalled_at = 0;
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let current = completed();
+        if current == previous {
+            stalled_at = current;
+            break;
+        }
+        previous = current;
+    }
 
     assert!(
-        first < MESSAGES as u64,
-        "the server validated all {MESSAGES} messages while the client read none, \
+        stalled_at > 0,
+        "the server never stopped making progress while the client read nothing, \
          so nothing is bounding it"
     );
-    assert_eq!(
-        first, second,
-        "progress must stop entirely while the client reads nothing, not merely slow down"
-    );
     assert!(
-        first > 0,
-        "the server should have made progress up to the bound, not stalled at zero"
+        stalled_at < MESSAGES as u64,
+        "the server validated all {MESSAGES} messages before stalling, which means the \
+         bound is above the offered work and this test proves nothing"
     );
+
+    let first = stalled_at;
 
     // The stall must be a stall, not a deadlock. Draining has to let the rest
     // through, or "backpressure" would just be a hang with a better name.

--- a/crates/vastlint-grpc/tests/backpressure.rs
+++ b/crates/vastlint-grpc/tests/backpressure.rs
@@ -1,0 +1,146 @@
+//! Streaming backpressure, measured rather than asserted.
+//!
+//! The claim in the handler's documentation is that a slow reader stalls the
+//! server rather than filling its memory. That is easy to write and easy to get
+//! wrong: an implementation that reads the inbound stream as fast as the client
+//! writes looks identical in every functional test and only differs under a
+//! producer the server cannot keep up with.
+//!
+//! ## Where the bound actually is
+//!
+//! The first version of this test sent 400 messages with a channel capacity of
+//! 2 and expected the server to stall almost immediately. All 400 completed.
+//! That was not a bug in the handler: the bounded channel bounds the handler's
+//! own queue, and between it and the client sit HTTP/2 flow-control windows and
+//! the transport's buffers, which happily absorb a few thousand small responses
+//! before anything pushes back.
+//!
+//! Raising the count to 20,000 shows the real behaviour: progress plateaus
+//! around 2,800 completed validations and stays flat for as long as the client
+//! declines to read, then resumes the moment it does. So the server is bounded,
+//! and it is bounded well below the offered work, but the number is set by the
+//! transport window rather than by the channel capacity. Anyone reasoning about
+//! per-stream memory should size it from the window, not from
+//! `VASTLINT_STREAM_BUFFER`.
+//!
+//! The test asserts the plateau rather than a threshold, because the threshold
+//! is a property of the transport's defaults and would be a brittle thing to
+//! encode.
+//!
+//! This test lives in its own file on purpose. Metrics are process-global, so a
+//! test that reads a counter has to be the only thing in its process
+//! incrementing it. Cargo compiles each integration test file into its own
+//! binary, which is what makes that possible.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tokio_stream::StreamExt;
+use tonic::transport::{Channel, Server};
+use tonic::Request;
+use vastlint_grpc::proto::vastlint_service_client::VastlintServiceClient;
+use vastlint_grpc::proto::vastlint_service_server::VastlintServiceServer;
+use vastlint_grpc::proto::ValidateStreamRequest;
+use vastlint_grpc::service::VastlintApi;
+
+/// Small enough that an unbounded implementation is obvious.
+const STREAM_BUFFER: usize = 2;
+
+/// Far more than the transport will buffer, so a stall is reachable. At 400 it
+/// is not: the whole batch fits in the flow-control window and completes.
+const MESSAGES: usize = 20_000;
+
+const DOCUMENT: &str = r#"<VAST version="4.1"><Ad id="1"><InLine></InLine></Ad></VAST>"#;
+
+/// Reads the count of completed stream validations out of the process-global
+/// registry. In-process, so no scrape endpoint is involved.
+fn completed() -> u64 {
+    vastlint_grpc::metrics::render()
+        .lines()
+        .find(|line| {
+            line.starts_with(
+                "vastlint_grpc_request_duration_seconds_count{method=\"ValidateStream\"",
+            )
+        })
+        .and_then(|line| line.rsplit(' ').next()?.parse().ok())
+        .unwrap_or(0)
+}
+
+async fn start() -> VastlintServiceClient<Channel> {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(VastlintServiceServer::new(
+                VastlintApi::new().with_stream_buffer(STREAM_BUFFER),
+            ))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("server runs");
+    });
+
+    VastlintServiceClient::connect(format!("http://{addr}"))
+        .await
+        .expect("client connects")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_client_that_does_not_read_stalls_the_server() {
+    let mut client = start().await;
+
+    let documents: Vec<_> = (0..MESSAGES)
+        .map(|i| ValidateStreamRequest {
+            request_id: format!("req-{i}"),
+            document: DOCUMENT.to_string(),
+            context: None,
+        })
+        .collect();
+
+    let mut inbound = client
+        .validate_stream(Request::new(tokio_stream::iter(documents)))
+        .await
+        .expect("stream opens")
+        .into_inner();
+
+    // Everything has been handed to the transport and nothing has been read
+    // back. A server with no bound anywhere would work through all of it.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    let first = completed();
+
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    let second = completed();
+
+    assert!(
+        first < MESSAGES as u64,
+        "the server validated all {MESSAGES} messages while the client read none, \
+         so nothing is bounding it"
+    );
+    assert_eq!(
+        first, second,
+        "progress must stop entirely while the client reads nothing, not merely slow down"
+    );
+    assert!(
+        first > 0,
+        "the server should have made progress up to the bound, not stalled at zero"
+    );
+
+    // The stall must be a stall, not a deadlock. Draining has to let the rest
+    // through, or "backpressure" would just be a hang with a better name.
+    let mut received = 0;
+    while let Some(response) = inbound.next().await {
+        let response = response.expect("no stream-level failure");
+        assert!(response.verdict.is_some(), "every message gets a verdict");
+        received += 1;
+    }
+
+    assert_eq!(received, MESSAGES, "draining the stream releases the rest");
+    assert_eq!(completed(), MESSAGES as u64);
+
+    eprintln!(
+        "stalled at {first} of {MESSAGES} completed with the client not reading, \
+         then drained to {MESSAGES}"
+    );
+}

--- a/crates/vastlint-grpc/tests/schema_compatibility.rs
+++ b/crates/vastlint-grpc/tests/schema_compatibility.rs
@@ -1,0 +1,219 @@
+//! BACKWARD compatibility for the validation event schema, proven rather than
+//! configured.
+//!
+//! A schema registry set to BACKWARD checks compatibility once, at registration
+//! time, when somebody remembers to register. That is a real check and it is
+//! not enough: it lives in a running service, it is easy to bypass with a
+//! force-register, and it says nothing until the schema is already being
+//! deployed.
+//!
+//! These tests do the same check on every commit, in the repository that owns
+//! the schema, in exactly the way `buf breaking` does for the protobuf
+//! contract. Two mechanisms reached from different directions: the registry
+//! enforces at registration, the test enforces at commit, and the one that
+//! catches a mistake before it is deployed is worth more.
+//!
+//! ## What BACKWARD actually means
+//!
+//! A reader using the NEW schema can read data written under an OLD one. It is
+//! the guarantee that matters when consumers upgrade before producers, and when
+//! a topic holds months of records written under schemas nobody is running any
+//! more.
+//!
+//! Concretely, within one subject:
+//!
+//!   - Adding a field with a default is allowed. Old data has no value for it;
+//!     the reader fills in the default.
+//!   - Adding a field without a default is not. The reader has nothing to put
+//!     there, and every old record becomes undecodable.
+//!   - Removing a field is allowed for readers, since the reader simply ignores
+//!     what it does not know about.
+//!   - Renaming is removal plus addition, so it fails on the addition half.
+//!
+//! Each of those is a test below, including the ones that must fail.
+
+use apache_avro::types::{Record, Value};
+use apache_avro::{from_avro_datum, to_avro_datum, Schema};
+
+/// The schema this build ships. The starting point for every evolution below.
+const CURRENT: &str = include_str!("../../../schemas/openadtech/vastlint/v1/validation_event.avsc");
+
+/// Writes a minimal record under `writer`, then reads it back under `reader`.
+///
+/// This is the whole compatibility question in one function: can a consumer on
+/// the reader schema decode bytes produced by a producer on the writer schema.
+fn read_old_data_with_new_schema(writer_json: &str, reader_json: &str) -> Result<Value, String> {
+    let writer = Schema::parse_str(writer_json).map_err(|error| error.to_string())?;
+    let reader = Schema::parse_str(reader_json).map_err(|error| error.to_string())?;
+
+    let mut record = Record::new(&writer).ok_or("writer schema is not a record")?;
+    record.put("event_id", Value::String("evt-1".to_string()));
+    record.put("occurred_at_ms", Value::Long(1));
+    record.put("document_type", Value::Enum(0, "VAST".to_string()));
+    record.put("effective_version", Value::Union(0, Box::new(Value::Null)));
+    record.put("valid", Value::Boolean(true));
+    record.put("errors", Value::Int(0));
+    record.put("warnings", Value::Int(0));
+    record.put("infos", Value::Int(0));
+    record.put("findings", Value::Array(vec![]));
+    record.put("catalog_version", Value::String("0.11.7".to_string()));
+    record.put("catalog_digest", Value::String("sha256:abc".to_string()));
+    record.put("engine_version", Value::String("0.11.7".to_string()));
+    record.put("caller", Value::Union(0, Box::new(Value::Null)));
+
+    let datum = to_avro_datum(&writer, record).map_err(|error| error.to_string())?;
+
+    let mut bytes = datum.as_slice();
+    from_avro_datum(&writer, &mut bytes, Some(&reader)).map_err(|error| error.to_string())
+}
+
+fn field(record: &Value, name: &str) -> Option<Value> {
+    let Value::Record(fields) = record else {
+        return None;
+    };
+    fields
+        .iter()
+        .find(|(field, _)| field == name)
+        .map(|(_, value)| value.clone())
+}
+
+/// Inserts a field into the schema JSON just before the closing bracket of the
+/// top-level field list, which is where a new field would realistically go.
+fn with_extra_field(schema_json: &str, field_json: &str) -> String {
+    let mut parsed: serde_json::Value = serde_json::from_str(schema_json).expect("schema is JSON");
+    let fields = parsed["fields"].as_array_mut().expect("fields is an array");
+    fields.push(serde_json::from_str(field_json).expect("field is JSON"));
+    parsed.to_string()
+}
+
+#[test]
+fn the_shipped_schema_reads_its_own_data() {
+    let value = read_old_data_with_new_schema(CURRENT, CURRENT).expect("self-compatible");
+    assert_eq!(
+        field(&value, "event_id"),
+        Some(Value::String("evt-1".to_string()))
+    );
+}
+
+/// The allowed evolution, and the one that will actually happen: somebody wants
+/// a new attribute on the event.
+#[test]
+fn adding_a_field_with_a_default_is_backward_compatible() {
+    let next = with_extra_field(
+        CURRENT,
+        r#"{"name":"wrapper_depth","type":"int","default":0}"#,
+    );
+
+    let value = read_old_data_with_new_schema(CURRENT, &next)
+        .expect("a reader on the new schema must read old data");
+
+    assert_eq!(
+        field(&value, "wrapper_depth"),
+        Some(Value::Int(0)),
+        "the reader fills in the default for data written before the field existed"
+    );
+}
+
+#[test]
+fn adding_an_optional_field_is_backward_compatible() {
+    let next = with_extra_field(
+        CURRENT,
+        r#"{"name":"origin_url","type":["null","string"],"default":null}"#,
+    );
+
+    let value = read_old_data_with_new_schema(CURRENT, &next).expect("optional additions are safe");
+
+    assert_eq!(
+        field(&value, "origin_url"),
+        Some(Value::Union(0, Box::new(Value::Null)))
+    );
+}
+
+/// The failure this whole file exists to catch. Without a default the reader
+/// has nothing to put in the field, so every record ever written becomes
+/// undecodable, and the topic's history is lost to the new consumer.
+#[test]
+fn adding_a_field_without_a_default_breaks_backward_compatibility() {
+    let next = with_extra_field(CURRENT, r#"{"name":"tenant_id","type":"string"}"#);
+
+    let result = read_old_data_with_new_schema(CURRENT, &next);
+
+    assert!(
+        result.is_err(),
+        "a required field with no default must not be readable against older data, \
+         otherwise this test is not checking anything"
+    );
+}
+
+/// A rename is a removal plus an addition, and the addition half is what fails.
+/// Worth its own test because "rename" sounds harmless in a pull request title.
+#[test]
+fn renaming_a_field_breaks_backward_compatibility() {
+    let mut parsed: serde_json::Value = serde_json::from_str(CURRENT).expect("schema is JSON");
+    let fields = parsed["fields"].as_array_mut().expect("fields");
+    for entry in fields.iter_mut() {
+        if entry["name"] == "catalog_digest" {
+            entry["name"] = serde_json::Value::String("ruleset_digest".to_string());
+        }
+    }
+
+    let result = read_old_data_with_new_schema(CURRENT, &parsed.to_string());
+
+    assert!(
+        result.is_err(),
+        "renaming a required field must fail: old records carry the old name and the \
+         reader requires the new one"
+    );
+}
+
+/// Dropping a field is safe in this direction, which is easy to get backwards.
+/// The reader ignores what it does not know about, so old data still decodes.
+/// It is FORWARD compatibility that a removal breaks, and this subject is not
+/// registered FORWARD.
+#[test]
+fn removing_an_optional_field_is_backward_compatible() {
+    let mut parsed: serde_json::Value = serde_json::from_str(CURRENT).expect("schema is JSON");
+    let fields = parsed["fields"].as_array_mut().expect("fields");
+    fields.retain(|entry| entry["name"] != "caller");
+
+    let value = read_old_data_with_new_schema(CURRENT, &parsed.to_string())
+        .expect("a reader may ignore a field it no longer knows about");
+
+    assert!(
+        field(&value, "caller").is_none(),
+        "the removed field is absent from the decoded record"
+    );
+}
+
+/// Enum symbols are the other place a schema quietly breaks. The default on the
+/// enum is what lets an old reader survive meeting a symbol added later.
+#[test]
+fn the_document_type_enum_has_a_default_for_unknown_symbols() {
+    let parsed: serde_json::Value = serde_json::from_str(CURRENT).expect("schema is JSON");
+    let fields = parsed["fields"].as_array().expect("fields");
+
+    let document_type = fields
+        .iter()
+        .find(|entry| entry["name"] == "document_type")
+        .expect("document_type present");
+
+    assert_eq!(
+        document_type["type"]["default"], "UNKNOWN",
+        "without an enum default, a reader meeting a document type added later fails to \
+         decode the whole record rather than the one field"
+    );
+
+    let severity_default = fields
+        .iter()
+        .find(|entry| entry["name"] == "findings")
+        .and_then(|entry| entry["type"]["items"]["fields"].as_array())
+        .and_then(|finding_fields| {
+            finding_fields
+                .iter()
+                .find(|entry| entry["name"] == "severity")
+        })
+        .map(|entry| entry["type"]["default"].clone())
+        .expect("severity present");
+
+    assert_eq!(severity_default, "UNKNOWN");
+}

--- a/crates/vastlint-grpc/tests/server.rs
+++ b/crates/vastlint-grpc/tests/server.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
+use tokio_stream::StreamExt;
 use tonic::transport::{Channel, Server};
 use tonic::Request;
 use vastlint_grpc::proto::vastlint_service_client::VastlintServiceClient;
@@ -187,23 +188,183 @@ async fn list_rules_serves_the_catalog() {
         .all(|rule| rule.source != RuleSource::Unspecified as i32));
 }
 
-/// The stub has to be visibly a stub. A caller that gets a stream which closes
-/// immediately would read it as "no findings".
 #[tokio::test]
-async fn validate_stream_reports_unimplemented() {
+async fn validate_stream_returns_a_verdict_per_document() {
     let mut client = start().await;
 
-    let outbound = tokio_stream::iter(vec![ValidateStreamRequest {
-        request_id: "1".to_string(),
-        document: INVALID_VAST.to_string(),
-        context: None,
-    }]);
+    let documents: Vec<_> = (0..20)
+        .map(|i| ValidateStreamRequest {
+            request_id: format!("req-{i}"),
+            document: INVALID_VAST.to_string(),
+            context: None,
+        })
+        .collect();
 
-    let status = client
-        .validate_stream(Request::new(outbound))
+    let mut inbound = client
+        .validate_stream(Request::new(tokio_stream::iter(documents)))
         .await
-        .expect_err("streaming is not implemented yet");
+        .expect("stream opens")
+        .into_inner();
 
-    assert_eq!(status.code(), tonic::Code::Unimplemented);
-    assert!(status.message().contains("Validate"));
+    let mut seen = std::collections::HashSet::new();
+    while let Some(response) = inbound.next().await {
+        let response = response.expect("no stream-level failure");
+        assert!(
+            response.error.is_none(),
+            "unexpected error: {:?}",
+            response.error
+        );
+
+        let verdict = response.verdict.expect("verdict present");
+        assert!(!verdict.valid);
+        assert!(!verdict.issues.is_empty());
+
+        assert!(
+            seen.insert(response.request_id.clone()),
+            "each request_id must be answered exactly once"
+        );
+    }
+
+    assert_eq!(seen.len(), 20, "every document must be answered");
+}
+
+/// The contract says responses may arrive out of order, so the correlation
+/// token is the only thing tying a verdict to its document. If the server
+/// echoed the wrong id, or dropped it, a caller would silently attribute
+/// findings to the wrong creative.
+#[tokio::test]
+async fn stream_responses_are_correlated_by_request_id() {
+    let mut client = start().await;
+
+    let valid = r#"<VAST version="4.1"><Ad id="1"><InLine><AdSystem>Example</AdSystem><AdTitle>Ad</AdTitle><AdServingId>abc</AdServingId><Impression><![CDATA[https://t.example.com/i]]></Impression><Creatives><Creative><UniversalAdId idRegistry="ad-id.org">UID</UniversalAdId><Linear><Duration>00:00:15</Duration><MediaFiles><MediaFile delivery="progressive" type="video/mp4" width="640" height="360"><![CDATA[https://cdn.example.com/a.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>"#;
+
+    // Interleaved so a server that answered positionally rather than by id
+    // would pair the wrong verdict with the wrong token.
+    let documents = vec![
+        ValidateStreamRequest {
+            request_id: "broken".to_string(),
+            document: INVALID_VAST.to_string(),
+            context: None,
+        },
+        ValidateStreamRequest {
+            request_id: "clean".to_string(),
+            document: valid.to_string(),
+            context: None,
+        },
+    ];
+
+    let mut inbound = client
+        .validate_stream(Request::new(tokio_stream::iter(documents)))
+        .await
+        .expect("stream opens")
+        .into_inner();
+
+    let mut verdicts = std::collections::HashMap::new();
+    while let Some(response) = inbound.next().await {
+        let response = response.expect("no stream-level failure");
+        verdicts.insert(
+            response.request_id,
+            response.verdict.expect("verdict present").valid,
+        );
+    }
+
+    assert_eq!(verdicts.get("broken"), Some(&false));
+    assert_eq!(verdicts.get("clean"), Some(&true));
+}
+
+/// A bad context on one message is that message's problem. Tearing down the
+/// stream would punish every other document on it for one caller mistake.
+#[tokio::test]
+async fn a_bad_message_fails_alone_and_the_stream_continues() {
+    let mut client = start().await;
+
+    let documents = vec![
+        ValidateStreamRequest {
+            request_id: "bad-context".to_string(),
+            document: INVALID_VAST.to_string(),
+            context: Some(ValidationContext {
+                rule_overrides: [("VAST-9.9-not-a-rule".to_string(), 4)]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            }),
+        },
+        ValidateStreamRequest {
+            request_id: "fine".to_string(),
+            document: INVALID_VAST.to_string(),
+            context: None,
+        },
+    ];
+
+    let mut inbound = client
+        .validate_stream(Request::new(tokio_stream::iter(documents)))
+        .await
+        .expect("stream opens")
+        .into_inner();
+
+    let mut responses = std::collections::HashMap::new();
+    while let Some(response) = inbound.next().await {
+        let response = response.expect("one bad message must not fail the call");
+        responses.insert(response.request_id.clone(), response);
+    }
+
+    let bad = responses.get("bad-context").expect("bad message answered");
+    let error = bad.error.as_ref().expect("error reported");
+    assert_eq!(error.code, tonic::Code::InvalidArgument as i32);
+    assert!(error.message.contains("VAST-9.9-not-a-rule"));
+    assert!(bad.verdict.is_none());
+
+    let fine = responses.get("fine").expect("good message answered");
+    assert!(fine.error.is_none());
+    assert!(fine.verdict.is_some(), "the stream kept working");
+}
+
+/// Streaming and unary must not disagree. If they did, a caller would get a
+/// different answer depending on how it asked, which is the drift the whole
+/// one-core-many-surfaces arrangement exists to prevent.
+#[tokio::test]
+async fn streaming_and_unary_agree() {
+    let mut client = start().await;
+
+    let unary = client
+        .validate(Request::new(ValidateRequest {
+            document: INVALID_VAST.to_string(),
+            context: None,
+        }))
+        .await
+        .expect("validate succeeds")
+        .into_inner()
+        .verdict
+        .expect("verdict present");
+
+    let mut inbound = client
+        .validate_stream(Request::new(tokio_stream::iter(vec![
+            ValidateStreamRequest {
+                request_id: "1".to_string(),
+                document: INVALID_VAST.to_string(),
+                context: None,
+            },
+        ])))
+        .await
+        .expect("stream opens")
+        .into_inner();
+
+    let streamed = inbound
+        .next()
+        .await
+        .expect("one response")
+        .expect("no failure")
+        .verdict
+        .expect("verdict present");
+
+    assert_eq!(unary.valid, streamed.valid);
+    assert_eq!(unary.summary, streamed.summary);
+    assert_eq!(
+        unary.issues.iter().map(|i| &i.rule_id).collect::<Vec<_>>(),
+        streamed
+            .issues
+            .iter()
+            .map(|i| &i.rule_id)
+            .collect::<Vec<_>>(),
+    );
 }

--- a/crates/vastlint-grpc/tests/server.rs
+++ b/crates/vastlint-grpc/tests/server.rs
@@ -1,0 +1,209 @@
+//! End-to-end tests over a real client and a real socket.
+//!
+//! The unit tests in `service.rs` call the trait directly, which skips
+//! encoding, the HTTP/2 framing, and the metadata path. These do not: each test
+//! here starts a server on an ephemeral port and talks to it with the generated
+//! client, so a break in the generated codecs or in deadline propagation shows
+//! up as a failing test rather than as a surprise for the first caller.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::{Channel, Server};
+use tonic::Request;
+use vastlint_grpc::proto::vastlint_service_client::VastlintServiceClient;
+use vastlint_grpc::proto::vastlint_service_server::VastlintServiceServer;
+use vastlint_grpc::proto::{
+    ListRulesRequest, RuleSource, Severity, ValidateRequest, ValidateStreamRequest,
+    ValidationContext,
+};
+use vastlint_grpc::service::VastlintApi;
+
+/// A tag missing every required InLine child. Chosen so the test does not
+/// depend on which specific rules exist, only that a plainly broken document
+/// produces findings.
+const INVALID_VAST: &str = r#"<VAST version="4.1"><Ad id="1"><InLine></InLine></Ad></VAST>"#;
+
+/// Starts a server on a port the OS picks, and returns a connected client.
+///
+/// Port 0 rather than a fixed port so tests can run concurrently, and on CI
+/// machines where something else already holds the usual gRPC port.
+async fn start() -> VastlintServiceClient<Channel> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind an ephemeral port");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(VastlintServiceServer::new(VastlintApi::new()))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .expect("server runs");
+    });
+
+    // The listener is already bound, so the connection cannot race the bind.
+    // Retrying anyway would hide a real regression in startup.
+    VastlintServiceClient::connect(format!("http://{addr}"))
+        .await
+        .expect("client connects")
+}
+
+#[tokio::test]
+async fn validate_round_trips_over_the_wire() {
+    let mut client = start().await;
+
+    let response = client
+        .validate(Request::new(ValidateRequest {
+            document: INVALID_VAST.to_string(),
+            context: None,
+        }))
+        .await
+        .expect("validate succeeds")
+        .into_inner();
+
+    let verdict = response.verdict.expect("verdict present");
+    assert!(!verdict.valid);
+    assert!(!verdict.issues.is_empty());
+
+    // Findings must survive encoding intact, not just be present.
+    let issue = &verdict.issues[0];
+    assert!(!issue.rule_id.is_empty());
+    assert!(!issue.message.is_empty());
+    assert_ne!(issue.severity, Severity::Unspecified as i32);
+
+    let provenance = verdict.provenance.expect("provenance present");
+    assert!(provenance.catalog_digest.starts_with("sha256:"));
+    assert!(!provenance.catalog_version.is_empty());
+}
+
+#[tokio::test]
+async fn a_valid_document_reports_no_errors() {
+    let mut client = start().await;
+
+    let valid = r#"<VAST version="4.1">
+  <Ad id="1">
+    <InLine>
+      <AdSystem>Example</AdSystem>
+      <AdTitle>Test Ad</AdTitle>
+      <AdServingId>abc123</AdServingId>
+      <Impression><![CDATA[https://track.example.com/imp]]></Impression>
+      <Creatives>
+        <Creative>
+          <UniversalAdId idRegistry="ad-id.org">UID-001</UniversalAdId>
+          <Linear>
+            <Duration>00:00:30</Duration>
+            <MediaFiles>
+              <MediaFile delivery="progressive" type="video/mp4" width="1920" height="1080"><![CDATA[https://cdn.example.com/ad.mp4]]></MediaFile>
+            </MediaFiles>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
+</VAST>"#;
+
+    let verdict = client
+        .validate(Request::new(ValidateRequest {
+            document: valid.to_string(),
+            context: None,
+        }))
+        .await
+        .expect("validate succeeds")
+        .into_inner()
+        .verdict
+        .expect("verdict present");
+
+    assert_eq!(
+        verdict.summary.expect("summary present").errors,
+        0,
+        "expected no errors, got: {:?}",
+        verdict
+            .issues
+            .iter()
+            .filter(|issue| issue.severity == Severity::Error as i32)
+            .map(|issue| (&issue.rule_id, &issue.message))
+            .collect::<Vec<_>>()
+    );
+    assert!(verdict.valid);
+}
+
+/// The metadata path is easy to get wrong and invisible until a caller with a
+/// tight budget shows up, so it is exercised over the real transport where the
+/// client sets `grpc-timeout` itself.
+#[tokio::test]
+async fn a_client_deadline_reaches_the_server() {
+    let mut client = start().await;
+
+    let mut request = Request::new(ValidateRequest {
+        document: INVALID_VAST.to_string(),
+        context: None,
+    });
+    request.set_timeout(Duration::from_secs(30));
+
+    assert!(
+        client.validate(request).await.is_ok(),
+        "30s is ample for one tag"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_rule_override_is_rejected_with_invalid_argument() {
+    let mut client = start().await;
+
+    let status = client
+        .validate(Request::new(ValidateRequest {
+            document: INVALID_VAST.to_string(),
+            context: Some(ValidationContext {
+                rule_overrides: [("VAST-9.9-not-a-rule".to_string(), 4)]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            }),
+        }))
+        .await
+        .expect_err("unknown rule id is rejected");
+
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert!(status.message().contains("VAST-9.9-not-a-rule"));
+}
+
+#[tokio::test]
+async fn list_rules_serves_the_catalog() {
+    let mut client = start().await;
+
+    let response = client
+        .list_rules(Request::new(ListRulesRequest::default()))
+        .await
+        .expect("list_rules succeeds")
+        .into_inner();
+
+    assert_eq!(response.rules.len(), vastlint_core::all_rules().len());
+    assert!(response
+        .rules
+        .iter()
+        .all(|rule| rule.source != RuleSource::Unspecified as i32));
+}
+
+/// The stub has to be visibly a stub. A caller that gets a stream which closes
+/// immediately would read it as "no findings".
+#[tokio::test]
+async fn validate_stream_reports_unimplemented() {
+    let mut client = start().await;
+
+    let outbound = tokio_stream::iter(vec![ValidateStreamRequest {
+        request_id: "1".to_string(),
+        document: INVALID_VAST.to_string(),
+        context: None,
+    }]);
+
+    let status = client
+        .validate_stream(Request::new(outbound))
+        .await
+        .expect_err("streaming is not implemented yet");
+
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
+    assert!(status.message().contains("Validate"));
+}

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -17,6 +17,156 @@
         "lru-cache": "^10.4.3"
       }
     },
+    "node_modules/@bufbuild/buf": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.72.0.tgz",
+      "integrity": "sha512-BwBKTX/WXkhAhqWJGrEKnqU03/4tK1O0OozSlwUMBCOEo8pLL3xu3M24RT3+umExEeM0wjlANO6axqGWMqtt4Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "buf": "bin/buf",
+        "protoc-gen-buf-breaking": "bin/protoc-gen-buf-breaking",
+        "protoc-gen-buf-lint": "bin/protoc-gen-buf-lint"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@bufbuild/buf-darwin-arm64": "1.72.0",
+        "@bufbuild/buf-darwin-x64": "1.72.0",
+        "@bufbuild/buf-linux-aarch64": "1.72.0",
+        "@bufbuild/buf-linux-armv7": "1.72.0",
+        "@bufbuild/buf-linux-x64": "1.72.0",
+        "@bufbuild/buf-win32-arm64": "1.72.0",
+        "@bufbuild/buf-win32-x64": "1.72.0"
+      }
+    },
+    "node_modules/@bufbuild/buf-darwin-arm64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.72.0.tgz",
+      "integrity": "sha512-rKHRvjwAThapxIoOn92vIoTjYSz5FmRemDRLU4BYT4T6QWMEC13PM3/pPnqVgsNKZ5aW7iYDm9ztnisEqSi5yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-darwin-x64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-x64/-/buf-darwin-x64-1.72.0.tgz",
+      "integrity": "sha512-4TQ1AGft8sGspNg9NMsEjsKKis7nGaVV8tZLnNa3cKUBmx22gwOnB6VRhgKWwjf+BDqr85lUEzQ6wHCboNUutg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "ideallyInert": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-aarch64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-aarch64/-/buf-linux-aarch64-1.72.0.tgz",
+      "integrity": "sha512-cbIsUcgM5bHhbZWcDaAXqaYOAi8N0c0u+NiDydwVmZ04Et3s1EZ3TDqfQDRzwvoBPDP+lsO6YuTRXX6nI28x4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "ideallyInert": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-armv7": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-armv7/-/buf-linux-armv7-1.72.0.tgz",
+      "integrity": "sha512-v/bXVsFL8YNm2HgosGb9r3+nAt4jQiUc3r3JipYuiVY3DAJZAjoEvcak6/BkxQMTEQz9Zb8gRRlule9IFkbc5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "ideallyInert": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-x64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-x64/-/buf-linux-x64-1.72.0.tgz",
+      "integrity": "sha512-4xHGXEjqFxo1wX1zMGq4CzhYt5++nrj4C7k30j+YmGtvqCnipfdSe+V6kknBYRfYswVZEUwUbQOh6pnMTcGcrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "ideallyInert": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-win32-arm64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-arm64/-/buf-win32-arm64-1.72.0.tgz",
+      "integrity": "sha512-WH7ClsoB9A0e/5fFhx0DLqLzillYPRdHBhlwzihgvjGci0bBdyJVHSQGf0B9uspCMU6sn6W/N1S9/2vvQBNMug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "ideallyInert": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-win32-x64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-x64/-/buf-win32-x64-1.72.0.tgz",
+      "integrity": "sha512-X3eWqFzhDmu8CYQZz+Fu7i+PgH+yUl8UwJ5+x+bhZRYAIdcijikthodk60c5u/qq42m1Z2XAnAGyp/mTf7IffA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "ideallyInert": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -600,7 +750,7 @@
     },
     "npm": {
       "name": "vastlint",
-      "version": "0.6.2",
+      "version": "0.11.7",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -750,7 +750,7 @@
     },
     "npm": {
       "name": "vastlint",
-      "version": "0.11.7",
+      "version": "0.11.8",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,10 @@
       "name": "vastlint-packages",
       "workspaces": [
         "packages/*"
-      ]
+      ],
+      "devDependencies": {
+        "@bufbuild/buf": "^1.72.0"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -21,6 +24,150 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@bufbuild/buf": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf/-/buf-1.72.0.tgz",
+      "integrity": "sha512-BwBKTX/WXkhAhqWJGrEKnqU03/4tK1O0OozSlwUMBCOEo8pLL3xu3M24RT3+umExEeM0wjlANO6axqGWMqtt4Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "buf": "bin/buf",
+        "protoc-gen-buf-breaking": "bin/protoc-gen-buf-breaking",
+        "protoc-gen-buf-lint": "bin/protoc-gen-buf-lint"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@bufbuild/buf-darwin-arm64": "1.72.0",
+        "@bufbuild/buf-darwin-x64": "1.72.0",
+        "@bufbuild/buf-linux-aarch64": "1.72.0",
+        "@bufbuild/buf-linux-armv7": "1.72.0",
+        "@bufbuild/buf-linux-x64": "1.72.0",
+        "@bufbuild/buf-win32-arm64": "1.72.0",
+        "@bufbuild/buf-win32-x64": "1.72.0"
+      }
+    },
+    "node_modules/@bufbuild/buf-darwin-arm64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-arm64/-/buf-darwin-arm64-1.72.0.tgz",
+      "integrity": "sha512-rKHRvjwAThapxIoOn92vIoTjYSz5FmRemDRLU4BYT4T6QWMEC13PM3/pPnqVgsNKZ5aW7iYDm9ztnisEqSi5yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-darwin-x64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-darwin-x64/-/buf-darwin-x64-1.72.0.tgz",
+      "integrity": "sha512-4TQ1AGft8sGspNg9NMsEjsKKis7nGaVV8tZLnNa3cKUBmx22gwOnB6VRhgKWwjf+BDqr85lUEzQ6wHCboNUutg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-aarch64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-aarch64/-/buf-linux-aarch64-1.72.0.tgz",
+      "integrity": "sha512-cbIsUcgM5bHhbZWcDaAXqaYOAi8N0c0u+NiDydwVmZ04Et3s1EZ3TDqfQDRzwvoBPDP+lsO6YuTRXX6nI28x4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-armv7": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-armv7/-/buf-linux-armv7-1.72.0.tgz",
+      "integrity": "sha512-v/bXVsFL8YNm2HgosGb9r3+nAt4jQiUc3r3JipYuiVY3DAJZAjoEvcak6/BkxQMTEQz9Zb8gRRlule9IFkbc5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-linux-x64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-linux-x64/-/buf-linux-x64-1.72.0.tgz",
+      "integrity": "sha512-4xHGXEjqFxo1wX1zMGq4CzhYt5++nrj4C7k30j+YmGtvqCnipfdSe+V6kknBYRfYswVZEUwUbQOh6pnMTcGcrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-win32-arm64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-arm64/-/buf-win32-arm64-1.72.0.tgz",
+      "integrity": "sha512-WH7ClsoB9A0e/5fFhx0DLqLzillYPRdHBhlwzihgvjGci0bBdyJVHSQGf0B9uspCMU6sn6W/N1S9/2vvQBNMug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bufbuild/buf-win32-x64": {
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/buf-win32-x64/-/buf-win32-x64-1.72.0.tgz",
+      "integrity": "sha512-X3eWqFzhDmu8CYQZz+Fu7i+PgH+yUl8UwJ5+x+bhZRYAIdcijikthodk60c5u/qq42m1Z2XAnAGyp/mTf7IffA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -606,7 +753,7 @@
     },
     "npm": {
       "name": "vastlint",
-      "version": "0.6.2",
+      "version": "0.11.7",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -753,7 +753,7 @@
     },
     "npm": {
       "name": "vastlint",
-      "version": "0.11.7",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "scripts": {
     "build": "npm run build --workspaces",
     "typecheck": "npm run typecheck --workspaces"
+  },
+  "devDependencies": {
+    "@bufbuild/buf": "^1.72.0"
   }
 }

--- a/proto/openadtech/vastlint/v1/vastlint.proto
+++ b/proto/openadtech/vastlint/v1/vastlint.proto
@@ -286,7 +286,8 @@ message Provenance {
   // Semantic version of the rule catalog, e.g. "0.11.7". Names a release.
   string catalog_version = 1;
 
-  // Content hash of the active ruleset, as "sha256:<hex>". Pins what the
+  // Content hash of the active ruleset, formatted as "sha256:" followed by
+  // lowercase hex. Pins what the
   // release actually carried, which is what catches a catalog modified between
   // tagged releases or a build with rules compiled out.
   string catalog_digest = 2;

--- a/proto/openadtech/vastlint/v1/vastlint.proto
+++ b/proto/openadtech/vastlint/v1/vastlint.proto
@@ -1,0 +1,454 @@
+// vastlint gRPC contract, v1.
+//
+// This file is the wire contract for calling the vastlint validation engine as
+// a service. It mirrors the public types of `vastlint-core` but is deliberately
+// not generated from them: the Rust API may change shape within a minor release
+// in ways that must not reach consumers of this contract.
+//
+// STABILITY POSTURE
+//
+// Assume every consumer of this file will never upgrade. Within `v1`:
+//
+//   - Fields are added, never renumbered and never repurposed.
+//   - Deleted field numbers go into a `reserved` range in the same commit.
+//   - Enums gain values at the end. A consumer that receives an unknown enum
+//     value must treat it as the `_UNSPECIFIED` case rather than rejecting the
+//     message.
+//   - A breaking change means publishing `openadtech.vastlint.v2` alongside this
+//     package and serving both through a deprecation window.
+//
+// This is enforced by `buf breaking` in CI, not by review. See `buf.yaml`.
+
+syntax = "proto3";
+
+package openadtech.vastlint.v1;
+
+// Validation and repair of IAB ad documents: VAST, VMAP, and DAAST.
+service VastlintService {
+  // Validate a single document.
+  rpc Validate(ValidateRequest) returns (ValidateResponse);
+
+  // Bulk validation over a bidirectional stream: creative catalogs, backfills,
+  // CI sweeps. Responses may be returned out of order, so callers correlate on
+  // `request_id`. The server applies flow control, so a client that reads
+  // slowly will see its writes block rather than see the server buffer without
+  // limit.
+  rpc ValidateStream(stream ValidateStreamRequest) returns (stream ValidateStreamResponse);
+
+  // Apply deterministic repairs and return the corrected document. Separate
+  // from Validate because it produces a modified artifact rather than a
+  // verdict, and because a caller granted validation access is not necessarily
+  // granted repair.
+  rpc Fix(FixRequest) returns (FixResponse);
+
+  // The rule catalog. Versioned independently of this contract: see the note on
+  // `Issue.rule_id`.
+  rpc ListRules(ListRulesRequest) returns (ListRulesResponse);
+}
+
+// ── Requests and responses ───────────────────────────────────────────────────
+//
+// Each RPC gets its own request and response types even where the payloads
+// coincide today, so that a field added for one call cannot appear on another
+// by accident. The parts that genuinely are the same, notably the verdict
+// itself, are factored into shared messages rather than duplicated.
+
+// Input to a single validation.
+message ValidateRequest {
+  // The document source. Required. Root element decides which rule chain runs.
+  string document = 1;
+
+  // Optional. Server defaults apply when absent.
+  ValidationContext context = 2;
+}
+
+// Result of a single validation.
+message ValidateResponse {
+  Verdict verdict = 1;
+}
+
+// One document in a validation stream.
+message ValidateStreamRequest {
+  // Client-supplied correlation token, echoed back unchanged. Required: it is
+  // the only way to match a response to its request, since the server may
+  // answer out of order. Never interpreted by the server, and not required to
+  // be unique, though a client that reuses one cannot demultiplex the results.
+  string request_id = 1;
+
+  string document = 2;
+  ValidationContext context = 3;
+}
+
+// One result in a validation stream.
+message ValidateStreamResponse {
+  string request_id = 1;
+
+  // Absent when `error` is set.
+  Verdict verdict = 2;
+
+  // Set when this one document failed in a way that does not end the stream,
+  // for example a request exceeding the size cap. The stream continues; other
+  // documents are unaffected. Failures that do end the stream arrive as a gRPC
+  // status on the call itself instead.
+  StreamError error = 3;
+}
+
+// A per-document failure that does not terminate the stream.
+message StreamError {
+  // gRPC status code, as the numeric value from google.rpc.Code. Carried as an
+  // int rather than an imported enum to keep this file dependency-free.
+  int32 code = 1;
+
+  string message = 2;
+}
+
+// Input to a repair.
+message FixRequest {
+  string document = 1;
+  ValidationContext context = 2;
+}
+
+// Result of a repair.
+message FixResponse {
+  // The repaired document. Always well formed. May differ structurally from the
+  // input beyond the listed fixes: XML comments and processing instructions do
+  // not survive the round trip.
+  string document = 1;
+
+  // Applied in document order.
+  repeated AppliedFix applied = 2;
+
+  // Findings that survived the repair pass and need a human.
+  repeated Issue remaining = 3;
+
+  Provenance provenance = 4;
+}
+
+// Request for the rule catalog.
+message ListRulesRequest {
+  // Optional filter. Empty means every source.
+  repeated RuleSource sources = 1;
+}
+
+// The rule catalog.
+message ListRulesResponse {
+  // Definition order, which is stable across releases for rules present in
+  // both.
+  repeated RuleMeta rules = 1;
+
+  Provenance provenance = 2;
+}
+
+// The outcome of validating one document. Shared by the unary and streaming
+// calls so the two can never drift apart.
+message Verdict {
+  // True when the document produced no findings at ERROR severity. Warnings and
+  // info findings do not affect it. Equivalent to `summary.errors == 0`,
+  // carried explicitly so callers do not reimplement the rule.
+  bool valid = 1;
+
+  DocumentType document_type = 2;
+  DetectedVersion detected_version = 3;
+
+  // Ordered by document position, depth first.
+  repeated Issue issues = 4;
+
+  Summary summary = 5;
+  Provenance provenance = 6;
+}
+
+// ── Core types ───────────────────────────────────────────────────────────────
+
+// A single validation finding.
+message Issue {
+  // Stable rule identifier, e.g. "VAST-2.0-root-version".
+  //
+  // Deliberately a string rather than an enum. The catalog moves faster than
+  // this contract does (108 rules in April 2026, 222 in August), and binding a
+  // fast-moving catalog to a slow-moving wire contract makes every new rule a
+  // contract change. The cost is that consumers get no compile-time checking of
+  // rule IDs. What buys that back:
+  //
+  //   1. An ID, once published, is permanent. It is never reused for a
+  //      different rule, including after the original rule is withdrawn.
+  //   2. Rules deprecate rather than disappear. A withdrawn rule stays in
+  //      ListRules with `deprecated` set and, where one exists, `superseded_by`
+  //      populated. A consumer pinning an old ID gets an explanation instead of
+  //      silence.
+  //   3. The ID format is frozen even though the set of IDs is not. Consumers
+  //      may match on the version prefix.
+  //
+  // Validate IDs against ListRules at startup rather than trusting a hardcoded
+  // list.
+  string rule_id = 1;
+
+  // Effective severity, after any caller override in ValidationContext. This is
+  // not necessarily the rule's default severity: compare against
+  // `RuleMeta.default_severity` from ListRules if that distinction matters.
+  Severity severity = 2;
+
+  string message = 3;
+
+  // XPath-like location, e.g. "/VAST/Ad[0]/InLine/AdSystem". Empty when the
+  // finding applies to the document as a whole.
+  string path = 4;
+
+  // Short spec citation, e.g. "IAB VAST 4.1 §3.4.1". Human-readable and not
+  // machine-parseable: its shape is not part of this contract.
+  string spec_ref = 5;
+
+  // 1-based position of the element that triggered the finding. Both are unset
+  // for document-level findings such as parse failures. `column` is a byte
+  // offset within the line, not a character offset, so it will not line up with
+  // a cursor position in a UTF-8 document containing multi-byte characters.
+  optional uint32 line = 6;
+  optional uint32 column = 7;
+}
+
+// Finding counts by severity.
+message Summary {
+  uint32 errors = 1;
+  uint32 warnings = 2;
+  uint32 infos = 3;
+}
+
+// A repair that was applied to the document.
+message AppliedFix {
+  string rule_id = 1;
+  string description = 2;
+  string path = 3;
+}
+
+// Caller-supplied validation settings. Every field is optional and the server
+// substitutes a default for anything absent.
+message ValidationContext {
+  // Current position in a wrapper chain. 0 means this document is the root.
+  // Set this when validating a document that was fetched by following a
+  // VASTAdTagURI, otherwise depth limits cannot be enforced correctly.
+  uint32 wrapper_depth = 1;
+
+  // Maximum permitted wrapper depth. Server default is 5, the IAB VAST 4.x
+  // recommendation. 0 means "use the server default" rather than "no wrappers
+  // permitted", because a default-constructed message must not silently change
+  // validation behaviour.
+  uint32 max_wrapper_depth = 2;
+
+  // Per-rule severity overrides, keyed by rule ID. Absent keys keep their
+  // default severity. Use RULE_LEVEL_OFF to silence a rule entirely.
+  //
+  // An unknown rule ID here is a client error, not a silent no-op: the server
+  // rejects the request with INVALID_ARGUMENT naming the offending IDs. A typo
+  // in a rule ID that silently disabled nothing would be indistinguishable from
+  // a rule that never fires.
+  map<string, RuleLevel> rule_overrides = 3;
+
+  // Validate against this version regardless of what the document declares.
+  // Unset means detect from the document, which is what almost every caller
+  // wants. Useful for templates and for tags whose version attribute is absent
+  // or wrong.
+  VastVersion forced_version = 4;
+}
+
+// How the document's VAST version was determined.
+//
+// Detection runs in two passes: the root element's `version` attribute is read
+// (declared), then document structure is scanned for version-specific elements
+// (inferred). When both are available they are compared, and disagreement is
+// itself a finding.
+//
+// Always DETECTION_SOURCE_UNKNOWN for VMAP and DAAST documents, whose own
+// version attributes are checked by their own rules.
+message DetectedVersion {
+  DetectionSource source = 1;
+
+  // Set when `source` is DECLARED or DECLARED_AND_INFERRED.
+  VastVersion declared = 2;
+
+  // Set when `source` is INFERRED or DECLARED_AND_INFERRED.
+  VastVersion inferred = 3;
+
+  // Meaningful only when `source` is DECLARED_AND_INFERRED. False means the
+  // document declares one version and is structurally another.
+  bool consistent = 4;
+
+  // The version validation actually ran against: the declared value when there
+  // is one, otherwise the inferred value, overridden by
+  // `ValidationContext.forced_version` when that was set.
+  VastVersion effective = 5;
+}
+
+// Everything needed to reproduce a verdict later.
+//
+// A verdict without its ruleset is not auditable, in the same way that a
+// question about an entity hierarchy is not answerable without an as-of date.
+// Both are questions about the past being asked of a model that has since moved.
+message Provenance {
+  // Semantic version of the rule catalog, e.g. "0.11.7". Names a release.
+  string catalog_version = 1;
+
+  // Content hash of the active ruleset, as "sha256:<hex>". Pins what the
+  // release actually carried, which is what catches a catalog modified between
+  // tagged releases or a build with rules compiled out.
+  string catalog_digest = 2;
+
+  // Version of the validation engine itself. Tracked separately from the
+  // catalog because the same ruleset evaluated by a different parser can reach
+  // a different verdict.
+  string engine_version = 3;
+}
+
+// Metadata for one rule in the catalog.
+message RuleMeta {
+  string rule_id = 1;
+  Severity default_severity = 2;
+  string description = 3;
+
+  // The external standard the rule derives from.
+  RuleSource source = 4;
+
+  // True when violating this rule has a direct revenue or measurement
+  // consequence: lost impressions, broken tracking, zero fill. Orthogonal to
+  // severity and to source. Some spec-mandated rules carry revenue impact and
+  // some best-practice rules do not.
+  bool revenue_impact = 5;
+
+  // Set when the rule is retained for identifier stability but no longer fires.
+  bool deprecated = 6;
+
+  // Rule ID that replaced this one, when there is a direct successor. Empty
+  // when the rule was withdrawn without replacement.
+  string superseded_by = 7;
+}
+
+// ── Enums ────────────────────────────────────────────────────────────────────
+
+// Severity assigned strictly on spec language.
+//
+//   ERROR   — the spec says "must" or "required". The tag will likely fail to
+//             serve.
+//   WARNING — the spec says "should" or "recommended", or the construct is
+//             deprecated.
+//   INFO    — advisory. Not a spec violation, but a known interoperability
+//             risk.
+enum Severity {
+  SEVERITY_UNSPECIFIED = 0;
+  SEVERITY_ERROR = 1;
+  SEVERITY_WARNING = 2;
+  SEVERITY_INFO = 3;
+}
+
+// A severity override. Mirrors Severity and adds OFF.
+//
+// A separate enum rather than a Severity plus a boolean, because "off" is not a
+// severity and modelling it as one invites a caller to send it where a real
+// severity is expected.
+enum RuleLevel {
+  RULE_LEVEL_UNSPECIFIED = 0;
+  RULE_LEVEL_ERROR = 1;
+  RULE_LEVEL_WARNING = 2;
+  RULE_LEVEL_INFO = 3;
+
+  // The rule does not run and produces no finding.
+  RULE_LEVEL_OFF = 4;
+}
+
+// IAB VAST versions.
+//
+// 4.4 is a working draft, not a published specification: `vast_4.4.xsd` landed
+// in the IAB VAST repository on 2026-07-17 annotated "DRAFT for working group
+// discussion". Documents declaring it validate rather than falling through as
+// unknown, but findings that exist only in 4.4 are reported at WARNING or INFO.
+enum VastVersion {
+  VAST_VERSION_UNSPECIFIED = 0;
+  VAST_VERSION_2_0 = 1;
+  VAST_VERSION_3_0 = 2;
+  VAST_VERSION_4_0 = 3;
+  VAST_VERSION_4_1 = 4;
+  VAST_VERSION_4_2 = 5;
+  VAST_VERSION_4_3 = 6;
+  VAST_VERSION_4_4 = 7;
+}
+
+// The kind of IAB ad document, decided by the root element. Any unrecognised
+// root is treated as VAST and validated as such, which is how a malformed VAST
+// document reports useful findings instead of one unhelpful one.
+enum DocumentType {
+  DOCUMENT_TYPE_UNSPECIFIED = 0;
+  DOCUMENT_TYPE_VAST = 1;
+  DOCUMENT_TYPE_VMAP = 2;
+  DOCUMENT_TYPE_DAAST = 3;
+}
+
+// How a document's version was established.
+enum DetectionSource {
+  DETECTION_SOURCE_UNSPECIFIED = 0;
+
+  // The version attribute was present and recognised.
+  DETECTION_SOURCE_DECLARED = 1;
+
+  // The version attribute was absent or unrecognised, so the version was
+  // inferred from document structure.
+  DETECTION_SOURCE_INFERRED = 2;
+
+  // Both were available. They may or may not agree: see
+  // DetectedVersion.consistent.
+  DETECTION_SOURCE_DECLARED_AND_INFERRED = 3;
+
+  // Neither could be established.
+  DETECTION_SOURCE_UNKNOWN = 4;
+}
+
+// The external standard a rule derives from.
+//
+// Callers filter on this to set their own alerting policy: hard-fail on
+// VAST_SPEC, log only on INFERRED. Values are added as vastlint implements
+// further standards, so treat an unrecognised value as UNSPECIFIED rather than
+// rejecting the response.
+enum RuleSource {
+  RULE_SOURCE_UNSPECIFIED = 0;
+
+  // IAB Tech Lab VAST specification, normative prose with section references.
+  RULE_SOURCE_VAST_SPEC = 1;
+
+  // IAB Tech Lab published VAST XSD schemas: structural and enum constraints.
+  RULE_SOURCE_VAST_XSD = 2;
+
+  // W3C XML 1.0 well-formedness.
+  RULE_SOURCE_XML = 3;
+
+  // RFC 3986 URI syntax.
+  RULE_SOURCE_RFC3986 = 4;
+
+  // IANA Media Types registry.
+  RULE_SOURCE_IANA_MEDIA_TYPES = 5;
+
+  // ISO 4217 currency codes.
+  RULE_SOURCE_ISO4217 = 6;
+
+  // Ad-ID registry format.
+  RULE_SOURCE_AD_ID = 7;
+
+  // A vastlint heuristic with no single external authority behind it.
+  RULE_SOURCE_INFERRED = 8;
+
+  // IAB Tech Lab SIMID specification.
+  RULE_SOURCE_SIMID_SPEC = 9;
+
+  // IAB Tech Lab VMAP 1.0.1 specification.
+  RULE_SOURCE_VMAP_SPEC = 10;
+
+  // IAB Tech Lab DAAST specification.
+  RULE_SOURCE_DAAST_SPEC = 11;
+
+  // IAB Tech Lab published DAAST XSD schema.
+  RULE_SOURCE_DAAST_XSD = 12;
+
+  // Industry practice derived from real ad serving behaviour, where violation
+  // has a direct revenue or measurement consequence.
+  RULE_SOURCE_INDUSTRY_BEST_PRACTICE = 13;
+
+  // IAB Tech Lab CTV Ad Portfolio signaling guidance, finalised 2026-07-22.
+  // Distinct from RULE_SOURCE_VAST_XSD because the guidance is a published
+  // final standard while the accompanying vast_4.4.xsd remains a draft.
+  RULE_SOURCE_CTV_AD_PORTFOLIO = 14;
+}

--- a/schemas/openadtech/vastlint/v1/validation_event.avsc
+++ b/schemas/openadtech/vastlint/v1/validation_event.avsc
@@ -1,0 +1,95 @@
+{
+  "type": "record",
+  "name": "ValidationEvent",
+  "namespace": "org.openadtech.vastlint.v1",
+  "doc": "One completed validation, published for consumers that want a stream of creative verdicts rather than a request-response call. An SSP watching for rejections is the motivating case: it wants to know which creatives are failing, not to ask about one at a time.\n\nCOMPATIBILITY: the subject is registered BACKWARD, meaning a reader on the current schema can read every record written under an older one. In practice that means fields are only ever added, and every added field carries a default. Removing a field, renaming one, or narrowing a type breaks it. Enforced by tests in this repository, not only by the registry: a registry checks at registration time, while the tests check on every commit.",
+  "fields": [
+    {
+      "name": "event_id",
+      "type": "string",
+      "doc": "Unique per event. Consumers deduplicate on this, because at-least-once delivery is the only guarantee on offer."
+    },
+    {
+      "name": "occurred_at_ms",
+      "type": "long",
+      "doc": "Unix milliseconds when validation completed. Not a logical timestamp: events can arrive out of order."
+    },
+    {
+      "name": "document_type",
+      "type": {
+        "type": "enum",
+        "name": "DocumentType",
+        "symbols": ["VAST", "VMAP", "DAAST", "UNKNOWN"],
+        "default": "UNKNOWN",
+        "doc": "The enum default matters. A consumer on an older schema that meets a document type added later resolves it to UNKNOWN instead of failing to decode the record."
+      }
+    },
+    {
+      "name": "effective_version",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "The VAST version validation ran against, e.g. \"4.1\". Null when it could not be determined."
+    },
+    {
+      "name": "valid",
+      "type": "boolean",
+      "doc": "True when no finding was at error severity."
+    },
+    {
+      "name": "errors",
+      "type": "int",
+      "default": 0,
+      "doc": "Finding counts, carried alongside the findings so a consumer aggregating rejection rates never has to decode the array."
+    },
+    { "name": "warnings", "type": "int", "default": 0 },
+    { "name": "infos", "type": "int", "default": 0 },
+    {
+      "name": "findings",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Finding",
+          "fields": [
+            {
+              "name": "rule_id",
+              "type": "string",
+              "doc": "A string for the same reason it is a string in the protobuf contract: the catalog moves faster than the schema. An Avro enum here would need a schema revision per rule, and the catalog went from 108 rules to 222 in four months."
+            },
+            {
+              "name": "severity",
+              "type": {
+                "type": "enum",
+                "name": "Severity",
+                "symbols": ["ERROR", "WARNING", "INFO", "UNKNOWN"],
+                "default": "UNKNOWN"
+              }
+            },
+            { "name": "message", "type": "string" },
+            {
+              "name": "path",
+              "type": ["null", "string"],
+              "default": null,
+              "doc": "XPath-like location. Null for findings about the document as a whole."
+            },
+            { "name": "spec_ref", "type": ["null", "string"], "default": null }
+          ]
+        }
+      },
+      "default": []
+    },
+    {
+      "name": "catalog_version",
+      "type": "string",
+      "doc": "Provenance, carried on every event for the same reason it is on every gRPC response: a verdict is only reproducible against the ruleset that produced it, and a consumer reading a topic weeks later has no other way to know which one that was."
+    },
+    { "name": "catalog_digest", "type": "string" },
+    { "name": "engine_version", "type": "string" },
+    {
+      "name": "caller",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "Caller identity from request metadata, when supplied. Self-asserted, so useful for attribution and not for authorization."
+    }
+  ]
+}


### PR DESCRIPTION
Adds a gRPC surface for vastlint, plus the ingress controls needed to run it somewhere real.

A validator that can only be called from a shell runs in CI and nowhere else. This is the transport for callers that need a verdict inside a request budget.

## What is here

- **`openadtech.vastlint.v1`** wire contract, hand-written rather than generated from the Rust types, with `buf lint`, `buf format`, and `buf breaking` wired into CI.
- **`vastlint-grpc`**: `Validate`, `Fix`, `ListRules`, and `ValidateStream`. Server reflection on v1 and v1alpha, `grpc.health.v1`, and `grpc-timeout` honoured.
- **Ingress control**: adaptive AIMD concurrency limiting with shedding to `RESOURCE_EXHAUSTED`, per-caller token bucket, request size caps at the decoder, Prometheus on a separate port.
- **A load harness and its results**, in [`LOAD-TEST.md`](crates/vastlint-grpc/LOAD-TEST.md).
- **A conformance test** requiring the CLI and gRPC surfaces to agree on the same document.
- **An Avro results stream** with BACKWARD compatibility proven by tests.
- **`Dockerfile.grpc`**: `FROM scratch`, publishing from the existing tag-gated pipeline.

## The measured result

Adaptive shedding, same server measured with the limiter off and on:

| | limiter off | limiter on |
| --- | ---: | ---: |
| p999 @ concurrency 128 | 47.42 ms | 7.79 ms |
| p999 @ concurrency 256 | 34.40 ms | 11.28 ms |
| goodput | baseline | 5–7% lower |
| requests refused | 0% | 2.4% |

Below capacity the two curves are within noise of each other, which is the point.

Three things the measurement changed, none visible from reading the code: the original 50ms target latency was inert (the server's own handling time never approaches it, so the limiter shed 0.02% and behaved like no limiter at all, now 2ms from the measured distribution); the real capacity knob was tokio's blocking pool, whose 512-thread default is sized for blocking I/O (sizing it to core count raised saturated goodput ~10%); and the first load corpus made the experiment meaningless, with a 340ms heavy document against a 0.2ms light one, so p999 measured which document was drawn rather than queueing.

## Two contract decisions worth reviewing

**Rule IDs are strings, not a proto enum.** The catalog went 108 → 222 rules in four months, and binding a fast-moving catalog to a slow-moving wire contract makes every new rule a contract change. The cost is no compile-time checking, bought back by a stability policy stated in the proto: IDs are permanent and never reused, rules deprecate rather than disappear, `ListRules` is discovery. Unknown IDs in `rule_overrides` are rejected rather than ignored, because a typo that silently disables nothing is indistinguishable from a rule that never fires.

**Every response carries `Provenance`**: catalog version, catalog content digest, engine version. The digest is computed over the linked catalog at runtime rather than the source at build time, so it still differs if rules were compiled out.

## Notes for review

- `ValidateStream` is exempt from the tower concurrency layer and admits per message instead. A stream is one HTTP request that lives for minutes, so sampling it as a single call would report its whole lifetime as one latency measurement and ratchet the limit to the floor.
- Streaming backpressure is bounded by the HTTP/2 flow-control window, not by `VASTLINT_STREAM_BUFFER`. Measured at ~2,800 buffered responses before the server stalls. Sizing guidance is in the README.
- `vastlint-grpc` is **not** published to crates.io, following `vastlint-mcp`. Its dev-dependency in `vastlint-cli` is path-only for that reason; with a version, `cargo publish -p vastlint-cli` fails.
- The `kafka` feature is off by default (vendored librdkafka is a multi-minute C build) and has not been tested against a live broker.
- The `buf breaking` step is guarded for this PR only, since main carries no proto to compare against yet.

## Still needs one-time setup

Buf Schema Registry publishing is wired but gated on `ENABLE_BSR_PUBLISH` and a `BUF_TOKEN` secret, matching how the Docker and npm jobs handle unset credentials.

434 tests pass. `cargo fmt`, `clippy --all-targets --all-features -D warnings`, `cargo doc -D warnings`, and `buf lint`/`format` all clean locally.