### PR TITLE
ci: build Docker images on every PR, and fix the BSR module name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,14 +190,21 @@ jobs:
       - name: buf breaking
         if: github.event_name == 'pull_request'
         run: |
-          if git ls-tree -r --name-only origin/main | grep -q '\.proto$'; then
-            npx buf breaking --against '.git#branch=main'
-          else
+          if ! git ls-tree -r --name-only origin/main | grep -q '\.proto$'; then
             echo "main carries no .proto files yet, so there is no prior contract to"
             echo "break. This branch should only be reachable on the PR that first"
             echo "adds the contract."
             exit 0
           fi
+
+          # buf resolves `branch=main` against a local branch, and checkout
+          # leaves the PR in a detached HEAD with only origin/main present, so
+          # the clone fails with "could not clone .git: exit status 128". The
+          # fetch creates the local branch buf is looking for. This did not show
+          # up on the pull request that introduced the contract, because the
+          # guard above short-circuited before buf ever ran.
+          git fetch --no-tags origin main:main
+          npx buf breaking --against '.git#branch=main'
 
   docker:
     name: Docker images build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,47 @@ jobs:
             exit 0
           fi
 
+  docker:
+    name: Docker images build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+      # Both images are built here and pushed nowhere. Until now the only thing
+      # that ever built them was a release, so a Dockerfile that no longer
+      # compiles would surface in the middle of publishing rather than on the
+      # pull request that broke it. Two other gates failed that way this week
+      # (cargo publish on a dev-dependency, and buf breaking with no prior
+      # contract), which is enough of a pattern to close this one deliberately.
+      #
+      # linux/amd64 only. The release builds amd64 and arm64 through QEMU, which
+      # roughly doubles the time for a second architecture that cannot fail
+      # independently here: the binary is a statically linked musl build with no
+      # architecture-specific code, and its dependencies are the same on both.
+      # Paying that on every pull request would buy very little.
+      - name: Build the CLI image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build the gRPC server image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          file: Dockerfile.grpc
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   codeql:
     name: CodeQL (SAST)
     runs-on: ubuntu-latest

--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -26,8 +26,12 @@ WORKDIR /build
 
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
-# The wire contract lives outside the crate, and build.rs reads it from here.
+# Both contracts live outside the crate. build.rs reads the proto, and the Avro
+# schema is include_str!'d into the binary so it cannot write records under a
+# schema it does not itself carry. Omitting either fails the build inside the
+# image only, which is why CI builds this file on every pull request now.
 COPY proto/ proto/
+COPY schemas/ schemas/
 
 RUN cargo build --release --bin vastlint-grpc
 


### PR DESCRIPTION
Release prep. Two gates that had never run, and one name that was wrong.

## Build both Docker images on every pull request

`Dockerfile.grpc` had never been built by anything. Neither image is built outside a release, so a Dockerfile that stops compiling surfaces in the middle of publishing rather than on the change that broke it.

The job found a real break on its first run: the gRPC image copied `proto/` but not `schemas/`, and the Avro schema is `include_str!`'d into the binary. Fine everywhere else, broken only inside the image. Since `ENABLE_DOCKER_PUBLISH` is already on with both secrets present, tagging would have run this for the first time during publishing.

`linux/amd64` only. The release builds arm64 as well through QEMU, which roughly doubles the time for an architecture that cannot fail independently here: a statically linked musl build with no architecture-specific code.

## Make `buf breaking` actually work

It resolves `branch=main` against a *local* branch, and `actions/checkout` leaves a PR in detached HEAD with only `origin/main`, so it failed with `could not clone .git: exit status 128`.

This could not have been caught on #112: the no-prior-protos guard short-circuited before buf ever ran, because main had no contract to compare against yet. The first branch to reach the real comparison is the one that found it. The gate protecting the wire contract has now run once, for real.

## Fix the BSR module name

The registry org is `open-adtech` with a hyphen. `buf.yaml` named `buf.build/openadtech/vastlint`, which does not exist, so the publish job would have failed the first time it ran, on a release.

The protobuf package stays `openadtech.vastlint.v1` without the hyphen. A BSR module name and a protobuf package are different namespaces with different rules, and renaming the package for cosmetic symmetry would be a breaking wire change.

## Still needed before BSR publishing works

- `gh secret set BUF_TOKEN` with a token from buf.build settings
- `gh variable set ENABLE_BSR_PUBLISH --body true`

Until both exist the job skips rather than fails, matching how the Docker and npm jobs handle unset credentials.