### PR TITLE
chore: bump quick-xml to 0.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1803,9 +1803,9 @@ checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -1863,7 +1863,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2104,7 +2104,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2482,7 +2482,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3137,7 +3137,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/vastlint-core/Cargo.toml
+++ b/crates/vastlint-core/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["vast", "xml", "validator", "simid", "ctv"]
 categories = ["parser-implementations", "development-tools"]
 
 [dependencies]
-quick-xml = { version = "0.41", features = [] }
+quick-xml = { version = "0.42", features = [] }
 url = "2"
 phf = { version = "0.14", features = ["macros"] }
 

--- a/crates/vastlint-core/src/inspect.rs
+++ b/crates/vastlint-core/src/inspect.rs
@@ -69,9 +69,7 @@ pub fn inspect_document(xml: &str) -> InspectDocumentMeta {
         match reader.read_event() {
             Ok(Event::Eof) | Err(_) => break,
             Ok(Event::Start(element)) => {
-                let name = std::str::from_utf8(element.name().as_ref())
-                    .unwrap_or("")
-                    .to_owned();
+                let name = element.name().as_ref().to_owned();
                 match name.as_str() {
                     "InLine" => meta.ad_type = InspectAdType::InLine,
                     "Wrapper" => meta.ad_type = InspectAdType::Wrapper,
@@ -89,14 +87,9 @@ pub fn inspect_document(xml: &str) -> InspectDocumentMeta {
                         let mut height = String::new();
                         let mut bitrate = String::new();
                         for attr in element.attributes().flatten() {
-                            let key = std::str::from_utf8(attr.key.as_ref())
-                                .unwrap_or("")
-                                .to_owned();
+                            let key = attr.key.as_ref().to_owned();
                             let value = attr
-                                .decoded_and_normalized_value(
-                                    XmlVersion::Implicit1_0,
-                                    reader.decoder(),
-                                )
+                                .normalized_value(XmlVersion::Implicit1_0)
                                 .map(|value| value.into_owned())
                                 .unwrap_or_default();
                             match key.as_str() {
@@ -115,25 +108,20 @@ pub fn inspect_document(xml: &str) -> InspectDocumentMeta {
                 }
             }
             Ok(Event::Text(text)) => {
-                if let Ok(value) = text.xml10_content() {
-                    apply_text(
-                        value.trim(),
-                        &mut meta,
-                        &mut target,
-                        &mut pending_media_file,
-                    );
-                }
+                apply_text(
+                    text.xml10_content().trim(),
+                    &mut meta,
+                    &mut target,
+                    &mut pending_media_file,
+                );
             }
             Ok(Event::CData(text)) => {
-                let bytes = text.into_inner();
-                if let Ok(value) = std::str::from_utf8(&bytes) {
-                    apply_text(
-                        value.trim(),
-                        &mut meta,
-                        &mut target,
-                        &mut pending_media_file,
-                    );
-                }
+                apply_text(
+                    text.into_inner().trim(),
+                    &mut meta,
+                    &mut target,
+                    &mut pending_media_file,
+                );
             }
             _ => {}
         }

--- a/crates/vastlint-core/src/parse.rs
+++ b/crates/vastlint-core/src/parse.rs
@@ -14,7 +14,7 @@ use quick_xml::Reader;
 /// (`xmlns` or `xmlns:foo`). The parser stores only local names, so this must be
 /// computed from the full qualified name before the prefix is discarded.
 fn is_namespaced(key: &QName) -> bool {
-    key.prefix().is_some() || key.as_ref() == b"xmlns"
+    key.prefix().is_some() || key.as_ref() == "xmlns"
 }
 
 // ── Internal document model ───────────────────────────────────────────────────
@@ -260,17 +260,11 @@ pub fn parse(input: &str) -> VastDocument {
                 let start_pos = end_pos.saturating_sub(tag_len);
                 let (line, col) = byte_offset_to_line_col(input_bytes, start_pos);
 
-                let name = std::str::from_utf8(e.local_name().as_ref())
-                    .unwrap_or("")
-                    .to_owned();
+                let name = e.local_name().as_ref().to_owned();
                 let mut attrs = Vec::new();
                 for attr in e.attributes().flatten() {
-                    let key = std::str::from_utf8(attr.key.local_name().as_ref())
-                        .unwrap_or("")
-                        .to_owned();
-                    let val = std::str::from_utf8(attr.value.as_ref())
-                        .unwrap_or("")
-                        .to_owned();
+                    let key = attr.key.local_name().as_ref().to_owned();
+                    let val = attr.value.as_ref().to_owned();
                     attrs.push(Attr {
                         namespaced: is_namespaced(&attr.key),
                         name: key,
@@ -296,17 +290,11 @@ pub fn parse(input: &str) -> VastDocument {
                 let start_pos = end_pos.saturating_sub(tag_len);
                 let (line, col) = byte_offset_to_line_col(input_bytes, start_pos);
 
-                let name = std::str::from_utf8(e.local_name().as_ref())
-                    .unwrap_or("")
-                    .to_owned();
+                let name = e.local_name().as_ref().to_owned();
                 let mut attrs = Vec::new();
                 for attr in e.attributes().flatten() {
-                    let key = std::str::from_utf8(attr.key.local_name().as_ref())
-                        .unwrap_or("")
-                        .to_owned();
-                    let val = std::str::from_utf8(attr.value.as_ref())
-                        .unwrap_or("")
-                        .to_owned();
+                    let key = attr.key.local_name().as_ref().to_owned();
+                    let val = attr.value.as_ref().to_owned();
                     attrs.push(Attr {
                         namespaced: is_namespaced(&attr.key),
                         name: key,
@@ -324,30 +312,24 @@ pub fn parse(input: &str) -> VastDocument {
 
             Ok(Event::Text(e)) => {
                 if let Some(node) = stack.last_mut() {
-                    if let Ok(text) = e.xml10_content() {
-                        append_text_segment(node, text.as_ref(), false);
-                    }
+                    append_text_segment(node, e.xml10_content().as_ref(), false);
                 }
             }
 
             Ok(Event::CData(e)) => {
                 if let Some(node) = stack.last_mut() {
-                    let bytes = e.into_inner();
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        append_text_segment(node, text, true);
-                    }
+                    append_text_segment(node, e.into_inner().as_ref(), true);
                 }
             }
 
             Ok(Event::GeneralRef(e)) => {
                 if let Some(node) = stack.last_mut() {
-                    if let Ok(reference) = std::str::from_utf8(e.as_ref()) {
-                        if let Some(decoded) = decode_general_reference(reference) {
-                            append_text_segment(node, &decoded, false);
-                        } else {
-                            let raw = format!("&{};", reference);
-                            append_text_segment(node, &raw, false);
-                        }
+                    let reference = e.as_ref();
+                    if let Some(decoded) = decode_general_reference(reference) {
+                        append_text_segment(node, &decoded, false);
+                    } else {
+                        let raw = format!("&{};", reference);
+                        append_text_segment(node, &raw, false);
                     }
                 }
             }

--- a/crates/vastlint-mcp/Cargo.toml
+++ b/crates/vastlint-mcp/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = "1"
 reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 
 # XML parsing for hop metadata extraction in inspect_vast
-quick-xml = { version = "0.41" }
+quick-xml = { version = "0.42" }
 
 # Fast allocator — critical for concurrent agent workloads
 mimalloc = { version = "0.1", default-features = false }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -413,7 +413,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vastlint-core"
-version = "0.6.2"
+version = "0.13.6"
 dependencies = [
  "phf",
  "quick-xml",


### PR DESCRIPTION
## Summary
- Bump `quick-xml` 0.41.0 to 0.42.0
- Port `inspect.rs` and `parse.rs` onto the 0.42 string API
- Refresh `fuzz/Cargo.lock`

Supersedes https://github.com/aleksUIX/vastlint/pull/123. GitHub left that PR's pull ref on the original Dependabot commit, so squash-merge could not see the port.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all`
- [x] `cargo audit` (chacha20 yanked warning allowed)